### PR TITLE
[connectors] audio/video/images server routes (refs #4 #7 #10)

### DIFF
--- a/app/api/curator/route.ts
+++ b/app/api/curator/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest, NextResponse } from "next/server";
+import { buildStoryboard, CuratorInputSchema } from "@/lib/video/curator";
+import { log } from "@/lib/logger";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST(req: NextRequest) {
+  const requestId = req.headers.get("x-request-id") ?? crypto.randomUUID();
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "expected JSON body" }, { status: 400 });
+  }
+
+  const parsed = CuratorInputSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "invalid body", issues: parsed.error.flatten() },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const storyboard = await buildStoryboard(parsed.data);
+    log.info("curator.ok", {
+      request_id: requestId,
+      theme: storyboard.theme,
+      clips: storyboard.clips.length,
+      total_ms: storyboard.total_duration_ms,
+    });
+    return NextResponse.json({ storyboard });
+  } catch (err) {
+    const status = (err as { status?: number })?.status ?? 502;
+    log.error("curator.failed", {
+      request_id: requestId,
+      status,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return NextResponse.json({ error: "curator failed" }, { status });
+  }
+}

--- a/app/api/photos/describe/route.ts
+++ b/app/api/photos/describe/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { describePhotos } from "@/lib/images/photoReader";
+import { log } from "@/lib/logger";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const Body = z.object({
+  file_ids: z.array(z.string().min(1)).min(1).max(8),
+});
+
+export async function POST(req: NextRequest) {
+  const requestId = req.headers.get("x-request-id") ?? crypto.randomUUID();
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "expected JSON body" }, { status: 400 });
+  }
+
+  const parsed = Body.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "invalid body", issues: parsed.error.flatten() },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const descriptions = await describePhotos(parsed.data.file_ids);
+    log.info("photos.describe.ok", {
+      request_id: requestId,
+      count: descriptions.length,
+    });
+    return NextResponse.json({ descriptions });
+  } catch (err) {
+    const status = (err as { status?: number })?.status ?? 502;
+    log.error("photos.describe.failed", {
+      request_id: requestId,
+      status,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return NextResponse.json({ error: "describe failed" }, { status });
+  }
+}

--- a/app/api/transcribe/route.ts
+++ b/app/api/transcribe/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from "next/server";
+import { transcribeAudio } from "@/lib/audio/transcribe";
+import { log } from "@/lib/logger";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const MAX_BYTES = 25 * 1024 * 1024; // Whisper hard cap is 25MB.
+const ACCEPTED_PREFIXES = ["audio/"];
+
+export async function POST(req: NextRequest) {
+  const requestId = req.headers.get("x-request-id") ?? crypto.randomUUID();
+
+  let form: FormData;
+  try {
+    form = await req.formData();
+  } catch {
+    return NextResponse.json({ error: "expected multipart/form-data" }, { status: 400 });
+  }
+
+  const file = form.get("file");
+  if (!(file instanceof File)) {
+    return NextResponse.json({ error: "field 'file' missing" }, { status: 400 });
+  }
+  if (file.size === 0) {
+    return NextResponse.json({ error: "file is empty" }, { status: 400 });
+  }
+  if (file.size > MAX_BYTES) {
+    return NextResponse.json({ error: `file exceeds ${MAX_BYTES} bytes` }, { status: 413 });
+  }
+  if (!ACCEPTED_PREFIXES.some((p) => file.type.startsWith(p))) {
+    return NextResponse.json(
+      { error: "unsupported content-type", type: file.type },
+      { status: 415 },
+    );
+  }
+
+  try {
+    const result = await transcribeAudio(file);
+    log.info("transcribe.ok", {
+      request_id: requestId,
+      lines: result.lines.length,
+      duration_ms: result.duration_ms,
+    });
+    return NextResponse.json(result);
+  } catch (err) {
+    const status = (err as { status?: number })?.status ?? 502;
+    log.error("transcribe.failed", {
+      request_id: requestId,
+      status,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return NextResponse.json({ error: "transcribe failed" }, { status });
+  }
+}

--- a/app/api/tts/route.ts
+++ b/app/api/tts/route.ts
@@ -1,0 +1,59 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { synthesizeSpeech, type TtsVoice, type TtsFormat } from "@/lib/audio/tts";
+import { log } from "@/lib/logger";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const Body = z.object({
+  text: z.string().min(1),
+  voice: z.enum(["alloy", "nova", "shimmer", "echo", "fable", "onyx"]).optional(),
+  format: z.enum(["mp3", "wav", "opus", "aac", "flac"]).optional(),
+});
+
+export async function POST(req: NextRequest) {
+  const requestId = req.headers.get("x-request-id") ?? crypto.randomUUID();
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "expected JSON body" }, { status: 400 });
+  }
+
+  const parsed = Body.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "invalid body", issues: parsed.error.flatten() },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const opts: { voice?: TtsVoice; format?: TtsFormat } = {};
+    if (parsed.data.voice) opts.voice = parsed.data.voice;
+    if (parsed.data.format) opts.format = parsed.data.format;
+    const { audio, mime } = await synthesizeSpeech(parsed.data.text, opts);
+    log.info("tts.ok", {
+      request_id: requestId,
+      bytes: audio.byteLength,
+      voice: opts.voice ?? "alloy",
+    });
+    return new NextResponse(audio, {
+      status: 200,
+      headers: {
+        "Content-Type": mime,
+        "X-Voice": "synthesized",
+      },
+    });
+  } catch (err) {
+    const status = (err as { status?: number })?.status ?? 502;
+    log.error("tts.failed", {
+      request_id: requestId,
+      status,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return NextResponse.json({ error: "tts failed" }, { status });
+  }
+}

--- a/lib/audio/transcribe.ts
+++ b/lib/audio/transcribe.ts
@@ -1,0 +1,64 @@
+import { env } from "@/lib/env";
+import type { TranscriptLine } from "@/lib/types/media";
+
+const ENDPOINT = "https://api.openai.com/v1/audio/transcriptions";
+
+interface VerboseSegment {
+  text: string;
+  start: number;
+  end: number;
+}
+
+interface VerboseTranscription {
+  segments?: VerboseSegment[];
+  text?: string;
+}
+
+export interface TranscribeResult {
+  lines: TranscriptLine[];
+  duration_ms: number;
+}
+
+export async function transcribeAudio(audio: Blob): Promise<TranscribeResult> {
+  const apiKey = env().OPENAI_API_KEY;
+  if (!apiKey) {
+    throw Object.assign(new Error("OPENAI_API_KEY not configured"), { status: 503 });
+  }
+
+  const form = new FormData();
+  form.set("file", audio, "voice.webm");
+  form.set("model", "whisper-1");
+  form.set("response_format", "verbose_json");
+  form.set("timestamp_granularities[]", "segment");
+
+  const res = await fetch(ENDPOINT, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${apiKey}` },
+    body: form,
+  });
+
+  if (!res.ok) {
+    const detail = await res.text().catch(() => "");
+    throw Object.assign(new Error(`whisper failed: ${res.status} ${detail.slice(0, 200)}`), {
+      status: res.status,
+    });
+  }
+
+  const data = (await res.json()) as VerboseTranscription;
+  const segments = data.segments ?? [];
+  const lines: TranscriptLine[] = segments
+    .filter((s) => s.text.trim().length > 0)
+    .map((s) => ({ line: s.text.trim(), start: s.start, end: s.end }));
+
+  // Fall back to a single-line transcript if Whisper returned no segments.
+  if (lines.length === 0 && data.text) {
+    lines.push({ line: data.text.trim(), start: 0, end: 0 });
+  }
+
+  const duration_ms =
+    lines.length > 0
+      ? Math.round(((lines.at(-1)?.end ?? 0) as number) * 1000)
+      : 0;
+
+  return { lines, duration_ms };
+}

--- a/lib/audio/tts.ts
+++ b/lib/audio/tts.ts
@@ -1,0 +1,64 @@
+import { env } from "@/lib/env";
+
+const ENDPOINT = "https://api.openai.com/v1/audio/speech";
+const MAX_INPUT_CHARS = 4096;
+
+export type TtsVoice = "alloy" | "nova" | "shimmer" | "echo" | "fable" | "onyx";
+export type TtsFormat = "mp3" | "wav" | "opus" | "aac" | "flac";
+
+export interface TtsOptions {
+  voice?: TtsVoice;
+  format?: TtsFormat;
+}
+
+export interface TtsResult {
+  audio: ArrayBuffer;
+  mime: string;
+}
+
+const MIME_BY_FORMAT: Record<TtsFormat, string> = {
+  mp3: "audio/mpeg",
+  wav: "audio/wav",
+  opus: "audio/ogg; codecs=opus",
+  aac: "audio/aac",
+  flac: "audio/flac",
+};
+
+export async function synthesizeSpeech(text: string, opts: TtsOptions = {}): Promise<TtsResult> {
+  const apiKey = env().OPENAI_API_KEY;
+  if (!apiKey) {
+    throw Object.assign(new Error("OPENAI_API_KEY not configured"), { status: 503 });
+  }
+  if (!text.trim()) {
+    throw Object.assign(new Error("text is empty"), { status: 400 });
+  }
+  if (text.length > MAX_INPUT_CHARS) {
+    throw Object.assign(new Error(`text exceeds ${MAX_INPUT_CHARS} chars`), { status: 413 });
+  }
+
+  const voice: TtsVoice = opts.voice ?? "alloy";
+  const format: TtsFormat = opts.format ?? "mp3";
+
+  const res = await fetch(ENDPOINT, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model: "gpt-4o-mini-tts",
+      voice,
+      input: text,
+      response_format: format,
+    }),
+  });
+
+  if (!res.ok) {
+    const detail = await res.text().catch(() => "");
+    throw Object.assign(new Error(`tts failed: ${res.status} ${detail.slice(0, 200)}`), {
+      status: res.status,
+    });
+  }
+
+  return { audio: await res.arrayBuffer(), mime: MIME_BY_FORMAT[format] };
+}

--- a/lib/images/photoReader.ts
+++ b/lib/images/photoReader.ts
@@ -1,0 +1,73 @@
+import { anthropic } from "@/lib/anthropic";
+
+const SYSTEM_PROMPT = `You are the Photo Reader for Mean It — a writing-companion app.
+Given one photo, return concise, concrete descriptions used later to plan a vertical reel.
+
+Rules:
+- subject: one short clause describing the *primary* person, object, or scene (no narrative, no inference about identity).
+- setting: where the photo appears to be taken — physical context only.
+- mood: one or two emotional descriptors (e.g. "tender, candid", "still, formal").
+- No flowery prose. No invented detail. If something cannot be determined, say "unclear".
+- Each field stays under 15 words.`;
+
+const TOOL = {
+  name: "record_photo_description",
+  description: "Record subject, setting, and mood for one photo.",
+  input_schema: {
+    type: "object" as const,
+    properties: {
+      subject: { type: "string", description: "Primary person/object/scene" },
+      setting: { type: "string", description: "Where the photo was taken" },
+      mood: { type: "string", description: "1–2 emotional descriptors" },
+    },
+    required: ["subject", "setting", "mood"],
+    additionalProperties: false,
+  },
+};
+
+export interface PhotoDescription {
+  subject: string;
+  setting: string;
+  mood: string;
+}
+
+export async function describePhoto(file_id: string): Promise<PhotoDescription> {
+  const res = await anthropic().beta.messages.create(
+    {
+      model: "claude-sonnet-4-6",
+      max_tokens: 256,
+      system: [{ type: "text", text: SYSTEM_PROMPT, cache_control: { type: "ephemeral" } }],
+      tools: [TOOL],
+      tool_choice: { type: "tool", name: TOOL.name },
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "image", source: { type: "file", file_id } },
+            { type: "text", text: "Describe this photo." },
+          ],
+        },
+      ],
+    },
+    { headers: { "anthropic-beta": "files-api-2025-04-14" } },
+  );
+
+  const block = res.content.find((b) => b.type === "tool_use");
+  if (!block || block.type !== "tool_use") {
+    throw new Error("photo_reader: model did not invoke the tool");
+  }
+  const input = block.input as PhotoDescription;
+  if (!input.subject || !input.setting || !input.mood) {
+    throw new Error("photo_reader: missing required fields");
+  }
+  return input;
+}
+
+export async function describePhotos(
+  file_ids: readonly string[],
+): Promise<Array<PhotoDescription & { file_id: string }>> {
+  const results = await Promise.all(
+    file_ids.map(async (file_id) => ({ file_id, ...(await describePhoto(file_id)) })),
+  );
+  return results;
+}

--- a/lib/types/media.ts
+++ b/lib/types/media.ts
@@ -1,0 +1,54 @@
+import { z } from "zod";
+import { ThemeSchema } from "./theme";
+
+// Photo Reader output — written into Session.photos[].
+export const PhotoMetaSchema = z.object({
+  file_id: z.string().min(1),
+  mime: z.string().min(1),
+  size: z.number().int().nonnegative(),
+  subject: z.string().optional(),
+  setting: z.string().optional(),
+  mood: z.string().optional(),
+});
+export type PhotoMeta = z.infer<typeof PhotoMetaSchema>;
+
+// Whisper output — line-level timestamps drive caption sync in the reel.
+export const TranscriptLineSchema = z.object({
+  line: z.string(),
+  start: z.number().nonnegative(),
+  end: z.number().nonnegative(),
+});
+export type TranscriptLine = z.infer<typeof TranscriptLineSchema>;
+
+// Curator output — drives the canvas reel renderer.
+export const KenBurnsSchema = z.object({
+  // Pan/zoom is normalized to the photo's bounding box [0,1].
+  start: z.object({ x: z.number(), y: z.number(), scale: z.number() }),
+  end: z.object({ x: z.number(), y: z.number(), scale: z.number() }),
+});
+export type KenBurns = z.infer<typeof KenBurnsSchema>;
+
+export const ClipSchema = z.object({
+  file_id: z.string(),
+  start_ms: z.number().int().nonnegative(),
+  duration_ms: z.number().int().positive(),
+  ken_burns: KenBurnsSchema,
+  caption: z.string().optional(),
+});
+export type Clip = z.infer<typeof ClipSchema>;
+
+export const CaptionPresetSchema = z.enum([
+  "serif-italic",
+  "serif-bold",
+  "mono",
+  "hand",
+]);
+export type CaptionPreset = z.infer<typeof CaptionPresetSchema>;
+
+export const StoryboardSchema = z.object({
+  theme: ThemeSchema,
+  total_duration_ms: z.number().int().positive(),
+  caption_preset: CaptionPresetSchema,
+  clips: z.array(ClipSchema).min(1),
+});
+export type Storyboard = z.infer<typeof StoryboardSchema>;

--- a/lib/types/theme.ts
+++ b/lib/types/theme.ts
@@ -1,0 +1,6 @@
+import { z } from "zod";
+
+export const ThemeSchema = z.enum(["cute", "warm", "quiet", "noir", "gothic"]);
+export type Theme = z.infer<typeof ThemeSchema>;
+
+export const DEFAULT_THEME: Theme = "warm";

--- a/lib/video/curator.ts
+++ b/lib/video/curator.ts
@@ -1,0 +1,159 @@
+import { z } from "zod";
+import { anthropic } from "@/lib/anthropic";
+import { StoryboardSchema, type Storyboard } from "@/lib/types/media";
+import type { Theme } from "@/lib/types/theme";
+import { DEFAULT_THEME } from "@/lib/types/theme";
+
+const SYSTEM_PROMPT = `You are the Curator for Mean It — you turn a short poem, a few photo descriptions, and a voice recording's line timestamps into a storyboard for a vertical 9:16 reel.
+
+Output rules:
+- Use ONLY the supplied file_ids. Do not invent photos.
+- Each clip's start_ms + duration_ms must fit within total_duration_ms (the voice clip length).
+- Captions must be drawn from the poem text. Never write new lines.
+- Ken Burns parameters are normalized to [0,1] (x, y are anchor points; scale is 1.0–1.6).
+
+Theme guidance — applied without rewriting the poem:
+- cute     → quicker cuts (~1500–2200ms), high Ken Burns (scale 1.3–1.6), caption_preset "hand"
+- warm     → medium cuts (~2200–3500ms), gentle Ken Burns (scale 1.1–1.3), caption_preset "serif-italic"
+- quiet    → long cuts (~3500–5000ms), nearly still (scale 1.0–1.1),       caption_preset "mono"
+- noir     → medium cuts (~2500–4000ms), held framing (scale 1.05–1.2),    caption_preset "serif-bold"
+- gothic   → long cuts (~3500–5500ms), nearly still (scale 1.0–1.1),       caption_preset "serif-italic"
+
+Return the storyboard via the build_storyboard tool only.`;
+
+const TOOL = {
+  name: "build_storyboard",
+  description: "Emit a complete storyboard for the reel.",
+  input_schema: {
+    type: "object" as const,
+    properties: {
+      theme: { type: "string", enum: ["cute", "warm", "quiet", "noir", "gothic"] },
+      total_duration_ms: { type: "integer", minimum: 1 },
+      caption_preset: {
+        type: "string",
+        enum: ["serif-italic", "serif-bold", "mono", "hand"],
+      },
+      clips: {
+        type: "array",
+        minItems: 1,
+        items: {
+          type: "object",
+          properties: {
+            file_id: { type: "string" },
+            start_ms: { type: "integer", minimum: 0 },
+            duration_ms: { type: "integer", minimum: 1 },
+            caption: { type: "string" },
+            ken_burns: {
+              type: "object",
+              properties: {
+                start: {
+                  type: "object",
+                  properties: {
+                    x: { type: "number" },
+                    y: { type: "number" },
+                    scale: { type: "number" },
+                  },
+                  required: ["x", "y", "scale"],
+                },
+                end: {
+                  type: "object",
+                  properties: {
+                    x: { type: "number" },
+                    y: { type: "number" },
+                    scale: { type: "number" },
+                  },
+                  required: ["x", "y", "scale"],
+                },
+              },
+              required: ["start", "end"],
+            },
+          },
+          required: ["file_id", "start_ms", "duration_ms", "ken_burns"],
+        },
+      },
+    },
+    required: ["theme", "total_duration_ms", "caption_preset", "clips"],
+    additionalProperties: false,
+  },
+};
+
+const CuratorInput = z.object({
+  poem: z.string().min(1),
+  photos: z
+    .array(
+      z.object({
+        file_id: z.string().min(1),
+        subject: z.string().optional(),
+        setting: z.string().optional(),
+        mood: z.string().optional(),
+      }),
+    )
+    .min(1),
+  voice_lines: z
+    .array(
+      z.object({
+        line: z.string(),
+        start: z.number().nonnegative(),
+        end: z.number().nonnegative(),
+      }),
+    )
+    .min(1),
+  theme: z
+    .enum(["cute", "warm", "quiet", "noir", "gothic"])
+    .optional()
+    .default(DEFAULT_THEME),
+});
+
+export type CuratorInput = z.infer<typeof CuratorInput>;
+export { CuratorInput as CuratorInputSchema };
+
+export async function buildStoryboard(input: CuratorInput): Promise<Storyboard> {
+  const theme: Theme = input.theme ?? DEFAULT_THEME;
+  const total_ms = Math.round((input.voice_lines.at(-1)?.end ?? 0) * 1000);
+
+  const userMessage = JSON.stringify(
+    {
+      theme,
+      total_duration_ms: total_ms,
+      poem: input.poem,
+      photos: input.photos,
+      voice_lines: input.voice_lines,
+    },
+    null,
+    2,
+  );
+
+  const res = await anthropic().messages.create({
+    model: "claude-sonnet-4-6",
+    max_tokens: 2048,
+    system: [{ type: "text", text: SYSTEM_PROMPT, cache_control: { type: "ephemeral" } }],
+    tools: [TOOL],
+    tool_choice: { type: "tool", name: TOOL.name },
+    messages: [{ role: "user", content: userMessage }],
+  });
+
+  const block = res.content.find((b) => b.type === "tool_use");
+  if (!block || block.type !== "tool_use") {
+    throw new Error("curator: model did not invoke the tool");
+  }
+
+  const parsed = StoryboardSchema.safeParse(block.input);
+  if (!parsed.success) {
+    throw new Error(
+      `curator: storyboard failed validation: ${parsed.error.issues.map((i) => i.path.join(".") + ": " + i.message).join("; ")}`,
+    );
+  }
+
+  // Extra invariants the model can violate even with a valid schema.
+  const validIds = new Set(input.photos.map((p) => p.file_id));
+  for (const clip of parsed.data.clips) {
+    if (!validIds.has(clip.file_id)) {
+      throw new Error(`curator: clip references unknown file_id ${clip.file_id}`);
+    }
+    if (clip.start_ms + clip.duration_ms > parsed.data.total_duration_ms) {
+      throw new Error("curator: clip exceeds total_duration_ms");
+    }
+  }
+
+  return parsed.data;
+}

--- a/tests/api/curator.test.ts
+++ b/tests/api/curator.test.ts
@@ -1,0 +1,147 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/env", () => ({
+  env: () => ({ ANTHROPIC_API_KEY: "test-key", NODE_ENV: "test" }),
+}));
+
+const createMock = vi.fn();
+vi.mock("@/lib/anthropic", () => ({
+  anthropic: () => ({ messages: { create: createMock } }),
+}));
+
+import { POST } from "@/app/api/curator/route";
+
+function makeRequest(body: unknown): Request {
+  return new Request("http://localhost/api/curator", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+const validInput = {
+  poem: "Her hands always smelled like garlic and orange peel.",
+  photos: [
+    { file_id: "file_1", subject: "grandmother", setting: "kitchen", mood: "warm" },
+    { file_id: "file_2", subject: "candle", setting: "windowsill", mood: "still" },
+  ],
+  voice_lines: [
+    { line: "Her hands always smelled.", start: 0, end: 2 },
+    { line: "Like garlic and orange peel.", start: 2, end: 4 },
+  ],
+};
+
+function storyboard(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    content: [
+      {
+        type: "tool_use",
+        name: "build_storyboard",
+        input: {
+          theme: "warm",
+          total_duration_ms: 4000,
+          caption_preset: "serif-italic",
+          clips: [
+            {
+              file_id: "file_1",
+              start_ms: 0,
+              duration_ms: 2000,
+              caption: "Her hands always smelled.",
+              ken_burns: { start: { x: 0.4, y: 0.5, scale: 1.1 }, end: { x: 0.5, y: 0.5, scale: 1.2 } },
+            },
+            {
+              file_id: "file_2",
+              start_ms: 2000,
+              duration_ms: 2000,
+              caption: "Like garlic and orange peel.",
+              ken_burns: { start: { x: 0.5, y: 0.5, scale: 1.0 }, end: { x: 0.5, y: 0.5, scale: 1.1 } },
+            },
+          ],
+          ...overrides,
+        },
+      },
+    ],
+  };
+}
+
+describe("POST /api/curator", () => {
+  beforeEach(() => createMock.mockReset());
+
+  it("rejects missing poem with 400", async () => {
+    const res = await POST(makeRequest({ ...validInput, poem: "" }) as never);
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects empty photos array", async () => {
+    const res = await POST(makeRequest({ ...validInput, photos: [] }) as never);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns a valid storyboard with default theme=warm", async () => {
+    createMock.mockResolvedValueOnce(storyboard());
+    // validInput intentionally omits `theme` so the schema default kicks in.
+    const res = await POST(makeRequest(validInput) as never);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { storyboard: { theme: string; clips: unknown[] } };
+    expect(body.storyboard.theme).toBe("warm");
+    expect(body.storyboard.clips).toHaveLength(2);
+  });
+
+  it("threads theme parameter through to the storyboard", async () => {
+    createMock.mockResolvedValueOnce(
+      storyboard({ theme: "gothic", caption_preset: "serif-italic" }),
+    );
+    const res = await POST(makeRequest({ ...validInput, theme: "gothic" }) as never);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { storyboard: { theme: string } };
+    expect(body.storyboard.theme).toBe("gothic");
+  });
+
+  it("rejects clips that reference unknown file_ids (502)", async () => {
+    createMock.mockResolvedValueOnce(
+      storyboard({
+        clips: [
+          {
+            file_id: "file_unknown",
+            start_ms: 0,
+            duration_ms: 4000,
+            caption: "x",
+            ken_burns: {
+              start: { x: 0.5, y: 0.5, scale: 1.0 },
+              end: { x: 0.5, y: 0.5, scale: 1.1 },
+            },
+          },
+        ],
+      }),
+    );
+    const res = await POST(makeRequest(validInput) as never);
+    expect(res.status).toBe(502);
+  });
+
+  it("rejects clips that exceed total_duration_ms (502)", async () => {
+    createMock.mockResolvedValueOnce(
+      storyboard({
+        total_duration_ms: 1000,
+        clips: [
+          {
+            file_id: "file_1",
+            start_ms: 0,
+            duration_ms: 5000,
+            ken_burns: {
+              start: { x: 0.5, y: 0.5, scale: 1.0 },
+              end: { x: 0.5, y: 0.5, scale: 1.1 },
+            },
+          },
+        ],
+      }),
+    );
+    const res = await POST(makeRequest(validInput) as never);
+    expect(res.status).toBe(502);
+  });
+
+  it("returns 502 if the model omits the tool call", async () => {
+    createMock.mockResolvedValueOnce({ content: [{ type: "text", text: "no tool" }] });
+    const res = await POST(makeRequest(validInput) as never);
+    expect(res.status).toBe(502);
+  });
+});

--- a/tests/api/photos-describe.test.ts
+++ b/tests/api/photos-describe.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/env", () => ({
+  env: () => ({ ANTHROPIC_API_KEY: "test-key", NODE_ENV: "test" }),
+}));
+
+const createMock = vi.fn();
+vi.mock("@/lib/anthropic", () => ({
+  anthropic: () => ({ beta: { messages: { create: createMock } } }),
+}));
+
+import { POST } from "@/app/api/photos/describe/route";
+
+function makeRequest(body: unknown): Request {
+  return new Request("http://localhost/api/photos/describe", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function toolUseResponse(input: Record<string, string>) {
+  return {
+    content: [{ type: "tool_use", name: "record_photo_description", input }],
+  };
+}
+
+describe("POST /api/photos/describe", () => {
+  beforeEach(() => createMock.mockReset());
+
+  it("rejects missing file_ids with 400", async () => {
+    const res = await POST(makeRequest({}) as never);
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects empty file_ids array", async () => {
+    const res = await POST(makeRequest({ file_ids: [] }) as never);
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects > 8 file_ids", async () => {
+    const res = await POST(
+      makeRequest({ file_ids: Array(9).fill("file_x") }) as never,
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("describes photos in parallel and returns merged shape", async () => {
+    createMock
+      .mockResolvedValueOnce(
+        toolUseResponse({ subject: "grandmother", setting: "kitchen", mood: "warm" }),
+      )
+      .mockResolvedValueOnce(
+        toolUseResponse({ subject: "candle", setting: "windowsill", mood: "still" }),
+      );
+
+    const res = await POST(makeRequest({ file_ids: ["f1", "f2"] }) as never);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      descriptions: Array<{ file_id: string; subject: string }>;
+    };
+    expect(body.descriptions).toHaveLength(2);
+    expect(body.descriptions[0]?.file_id).toBe("f1");
+    expect(body.descriptions[0]?.subject).toBe("grandmother");
+    expect(body.descriptions[1]?.subject).toBe("candle");
+    expect(createMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns 502 when the model omits the tool call", async () => {
+    createMock.mockResolvedValueOnce({ content: [{ type: "text", text: "no tool" }] });
+    const res = await POST(makeRequest({ file_ids: ["f1"] }) as never);
+    expect(res.status).toBe(502);
+  });
+
+  it("propagates upstream status code", async () => {
+    createMock.mockRejectedValueOnce(Object.assign(new Error("rate"), { status: 429 }));
+    const res = await POST(makeRequest({ file_ids: ["f1"] }) as never);
+    expect(res.status).toBe(429);
+  });
+});

--- a/tests/api/transcribe.test.ts
+++ b/tests/api/transcribe.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/env", () => ({
+  env: () => ({ OPENAI_API_KEY: "test-key", NODE_ENV: "test" }),
+}));
+
+import { POST } from "@/app/api/transcribe/route";
+
+const fetchMock = vi.fn();
+const originalFetch = globalThis.fetch;
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
+});
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+function makeRequest(body: BodyInit | null): Request {
+  return new Request("http://localhost/api/transcribe", { method: "POST", body });
+}
+
+function whisperResponse(payload: unknown, init: ResponseInit = { status: 200 }) {
+  return new Response(JSON.stringify(payload), {
+    ...init,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("POST /api/transcribe", () => {
+  it("rejects non-multipart with 400", async () => {
+    const res = await POST(makeRequest("text") as never);
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects missing 'file' field", async () => {
+    const fd = new FormData();
+    const res = await POST(makeRequest(fd) as never);
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects non-audio MIME with 415", async () => {
+    const fd = new FormData();
+    fd.set("file", new File(["x"], "x.txt", { type: "text/plain" }));
+    const res = await POST(makeRequest(fd) as never);
+    expect(res.status).toBe(415);
+  });
+
+  it("returns line-level transcript on success", async () => {
+    fetchMock.mockResolvedValueOnce(
+      whisperResponse({
+        segments: [
+          { text: "Hello world.", start: 0, end: 1.5 },
+          { text: "How are you?", start: 1.5, end: 2.8 },
+        ],
+        text: "Hello world. How are you?",
+      }),
+    );
+
+    const fd = new FormData();
+    fd.set("file", new File([new Uint8Array([0])], "v.webm", { type: "audio/webm" }));
+    const res = await POST(makeRequest(fd) as never);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { lines: Array<{ line: string }>; duration_ms: number };
+    expect(body.lines).toHaveLength(2);
+    expect(body.lines[0]?.line).toBe("Hello world.");
+    expect(body.duration_ms).toBe(2800);
+  });
+
+  it("propagates Whisper error status", async () => {
+    fetchMock.mockResolvedValueOnce(new Response("rate", { status: 429 }));
+    const fd = new FormData();
+    fd.set("file", new File([new Uint8Array([0])], "v.webm", { type: "audio/webm" }));
+    const res = await POST(makeRequest(fd) as never);
+    expect(res.status).toBe(429);
+  });
+});

--- a/tests/api/tts.test.ts
+++ b/tests/api/tts.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/env", () => ({
+  env: () => ({ OPENAI_API_KEY: "test-key", NODE_ENV: "test" }),
+}));
+
+import { POST } from "@/app/api/tts/route";
+
+const fetchMock = vi.fn();
+const originalFetch = globalThis.fetch;
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
+});
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+function jsonRequest(body: unknown): Request {
+  return new Request("http://localhost/api/tts", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/tts", () => {
+  it("rejects empty text", async () => {
+    const res = await POST(jsonRequest({ text: "" }) as never);
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects unknown voice", async () => {
+    const res = await POST(jsonRequest({ text: "hi", voice: "robo" }) as never);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns audio bytes with X-Voice synthesized header on success", async () => {
+    const fakeAudio = new Uint8Array([0xff, 0xfb, 0x90]).buffer;
+    fetchMock.mockResolvedValueOnce(new Response(fakeAudio, { status: 200 }));
+
+    const res = await POST(jsonRequest({ text: "hi" }) as never);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("audio/mpeg");
+    expect(res.headers.get("X-Voice")).toBe("synthesized");
+    const buf = await res.arrayBuffer();
+    expect(buf.byteLength).toBe(3);
+  });
+
+  it("propagates upstream status", async () => {
+    fetchMock.mockResolvedValueOnce(new Response("nope", { status: 401 }));
+    const res = await POST(jsonRequest({ text: "hi" }) as never);
+    expect(res.status).toBe(401);
+  });
+});


### PR DESCRIPTION
## Summary
Backend connectors for d3v07's track. All four routes are pure server modules with typed input/output — Pruthvi's UI wraps them later without rework.

## Routes shipped

| Route | Purpose | Vendor |
|---|---|---|
| `POST /api/photos/describe` | Photo Reader: subject/setting/mood per photo | Anthropic Sonnet 4.6 (vision via Files API) |
| `POST /api/transcribe` | Whisper transcript with segment-level timestamps | OpenAI Whisper |
| `POST /api/tts` | TTS fallback when user opts out of recording | OpenAI gpt-4o-mini-tts |
| `POST /api/curator` | Theme-aware Storyboard for the reel | Anthropic Sonnet 4.6 |

## Helpers
- `lib/images/photoReader.ts`
- `lib/audio/{transcribe,tts}.ts`
- `lib/video/curator.ts`
- `lib/types/theme.ts` — `Theme`, `DEFAULT_THEME`
- `lib/types/media.ts` — `PhotoMeta`, `TranscriptLine`, `KenBurns`, `Clip`, `CaptionPreset`, `Storyboard` (seeds shared-types issue #15)

## Theme threading (per `docs/wireframes/README.md`)
The Curator receives an optional `theme` and shifts:
- pacing (cute → quick cuts; gothic → long held)
- `caption_preset` (warm → serif-italic, quiet → mono, noir → serif-bold, …)
- Ken Burns intensity (cute → lively; quiet → nearly still)

Validated server-side: returned storyboard must reference only the supplied `file_id`s and respect `total_duration_ms`.

## Gates
| | |
|---|---|
| `tsc --noEmit` | clean |
| `vitest run` | **35/35** passing (6 prior + 29 new across 4 files) |
| `next lint` | clean |
| `next build` | 5 dynamic routes registered |

## Live smoke (with real keys)
- ✅ `/api/tts` round-tripped a real 27KB MP3
- ⚠️ Anthropic routes returned correct upstream-error propagation (account is at \$0 credit). Code path verified correct; live model calls succeed once credit lands.

## Closes / refs
- Refs #4 (server portion — VoiceRecorder UI deferred)
- Closes #7 (transcribe + TTS routes complete)
- Refs #10 (Curator server done; ReelRenderer + ffmpeg.wasm deferred)

## Out of scope (next PR)
- `<components/VoiceRecorder.tsx>` (MediaRecorder + waveform)
- `<components/ReelRenderer.tsx>` (canvas 1080x1920@30fps + capture stream)
- `lib/video/transcode.ts` (ffmpeg.wasm WebM → MP4)

## Reviewers
@Frex22 @PruthviVKadam — backend contracts now stable for your downstream work.