### PR TITLE
feat: shared session types (Closes #15)

### DIFF
--- a/lib/types/session.ts
+++ b/lib/types/session.ts
@@ -1,24 +1,16 @@
 import { z } from "zod";
+import { ThemeSchema, DEFAULT_THEME, type Theme } from "./theme";
+import { PhotoMetaSchema, type PhotoMeta } from "./media";
 
-// Theme — visual register the page artifact and reel renderer adopt.
-export const ThemeSchema = z.enum(["cute", "warm", "quiet", "noir", "gothic"]);
-export type Theme = z.infer<typeof ThemeSchema>;
+// Re-export the canonical Theme / PhotoMeta from their dedicated modules so
+// callers have one entry point (`@/lib/types/session`) without two sources
+// of truth. ThemeSchema / PhotoMetaSchema live next to their consumers in
+// `./theme` and `./media` respectively.
+export { ThemeSchema, DEFAULT_THEME, type Theme, PhotoMetaSchema, type PhotoMeta };
 
 // Form — the artifact form being authored. v1 scope per DESIGN.md §4.
 export const FormSchema = z.enum(["poem", "letter"]);
 export type Form = z.infer<typeof FormSchema>;
-
-// Populated by Photo Reader (#4); subject/setting/mood land after the
-// vision call returns.
-export const PhotoMetaSchema = z.object({
-  file_id: z.string().min(1),
-  mime: z.string().min(1),
-  size: z.number().int().nonnegative(),
-  subject: z.string().optional(),
-  setting: z.string().optional(),
-  mood: z.string().optional(),
-});
-export type PhotoMeta = z.infer<typeof PhotoMetaSchema>;
 
 // Appended whenever the audit layer (#9) inspects an assistant message.
 // `blocked` defaults to false so the audit can run in log-only mode.

--- a/lib/types/session.ts
+++ b/lib/types/session.ts
@@ -1,0 +1,96 @@
+import { z } from "zod";
+
+// Theme — visual register the page artifact and reel renderer adopt.
+export const ThemeSchema = z.enum(["cute", "warm", "quiet", "noir", "gothic"]);
+export type Theme = z.infer<typeof ThemeSchema>;
+
+// Form — the artifact form being authored. v1 scope per DESIGN.md §4.
+export const FormSchema = z.enum(["poem", "letter"]);
+export type Form = z.infer<typeof FormSchema>;
+
+// Populated by Photo Reader (#4); subject/setting/mood land after the
+// vision call returns.
+export const PhotoMetaSchema = z.object({
+  file_id: z.string().min(1),
+  mime: z.string().min(1),
+  size: z.number().int().nonnegative(),
+  subject: z.string().optional(),
+  setting: z.string().optional(),
+  mood: z.string().optional(),
+});
+export type PhotoMeta = z.infer<typeof PhotoMetaSchema>;
+
+// Appended whenever the audit layer (#9) inspects an assistant message.
+// `blocked` defaults to false so the audit can run in log-only mode.
+export const AuditEntrySchema = z.object({
+  ts: z.number().int(),
+  message_id: z.string().min(1),
+  flags_tripped: z.array(z.string()).min(1),
+  reason: z.string(),
+  blocked: z.boolean().default(false),
+});
+export type AuditEntry = z.infer<typeof AuditEntrySchema>;
+
+// Top-level state container. Persisted to localStorage; never round-trips
+// the network as a whole (routes consume slices).
+export const SessionSchema = z.object({
+  id: z.string().min(1),
+  recipient: z.string().min(1),
+  occasion: z.string().min(1),
+  form: FormSchema,
+  guide_id: z.string().min(1),
+  theme: ThemeSchema,
+  photos: z.array(PhotoMetaSchema).default([]),
+  audit: z.array(AuditEntrySchema).default([]),
+  created_at: z.number().int(),
+});
+export type Session = z.infer<typeof SessionSchema>;
+
+export const TurnRoleSchema = z.enum(["guide", "user"]);
+export type TurnRole = z.infer<typeof TurnRoleSchema>;
+
+// `phrases_held` is populated by the spine extractor (#6) for user turns
+// whose phrases became candidates for the artifact's spine.
+export const TurnSchema = z.object({
+  id: z.string().min(1),
+  session_id: z.string().min(1),
+  role: TurnRoleSchema,
+  text: z.string(),
+  ts: z.number().int(),
+  phrases_held: z.array(z.string()).optional(),
+});
+export type Turn = z.infer<typeof TurnSchema>;
+
+export const ProvenanceMatchSchema = z.enum(["exact", "fuzzy", "none"]);
+export type ProvenanceMatch = z.infer<typeof ProvenanceMatchSchema>;
+
+// Output of the deterministic provenance matcher (#9). One per artifact line.
+export const ProvenanceLineSchema = z.object({
+  line: z.string(),
+  source_turn_id: z.string(),
+  source_text: z.string(),
+  match: ProvenanceMatchSchema,
+});
+export type ProvenanceLine = z.infer<typeof ProvenanceLineSchema>;
+
+// Final rendered piece + provenance trace + byline meter input.
+export const ArtifactSchema = z.object({
+  session_id: z.string().min(1),
+  text: z.string(),
+  provenance: z.array(ProvenanceLineSchema),
+  byline_pct: z.number().min(0).max(100),
+  created_at: z.number().int(),
+});
+export type Artifact = z.infer<typeof ArtifactSchema>;
+
+export const CritiqueKindSchema = z.enum(["cliche", "question", "verified"]);
+export type CritiqueKind = z.infer<typeof CritiqueKindSchema>;
+
+// Emitted by the drafting critic (#8). `line_ref` ties the card to a
+// specific line of the user's draft when applicable.
+export const CritiqueCardSchema = z.object({
+  kind: CritiqueKindSchema,
+  line_ref: z.string().optional(),
+  body: z.string().min(1),
+});
+export type CritiqueCard = z.infer<typeof CritiqueCardSchema>;

--- a/tests/types/session.test.ts
+++ b/tests/types/session.test.ts
@@ -1,0 +1,243 @@
+import { describe, expect, it } from "vitest";
+import {
+  ArtifactSchema,
+  AuditEntrySchema,
+  CritiqueCardSchema,
+  FormSchema,
+  PhotoMetaSchema,
+  ProvenanceLineSchema,
+  SessionSchema,
+  ThemeSchema,
+  TurnSchema,
+} from "@/lib/types/session";
+
+describe("ThemeSchema", () => {
+  it("accepts each valid theme", () => {
+    for (const t of ["cute", "warm", "quiet", "noir", "gothic"] as const) {
+      expect(ThemeSchema.parse(t)).toBe(t);
+    }
+  });
+
+  it("rejects unknown themes", () => {
+    expect(() => ThemeSchema.parse("ugly")).toThrow();
+  });
+});
+
+describe("FormSchema", () => {
+  it("round-trips poem and letter", () => {
+    expect(FormSchema.parse("poem")).toBe("poem");
+    expect(FormSchema.parse("letter")).toBe("letter");
+  });
+});
+
+describe("PhotoMetaSchema", () => {
+  it("round-trips with all fields", () => {
+    const obj = {
+      file_id: "f_1",
+      mime: "image/jpeg",
+      size: 1024,
+      subject: "grandma at the kitchen table",
+      setting: "October kitchen",
+      mood: "warm",
+    };
+    expect(PhotoMetaSchema.parse(obj)).toEqual(obj);
+  });
+
+  it("round-trips with only required fields", () => {
+    const obj = { file_id: "f_1", mime: "image/jpeg", size: 1024 };
+    expect(PhotoMetaSchema.parse(obj)).toEqual(obj);
+  });
+
+  it("rejects negative size", () => {
+    expect(() =>
+      PhotoMetaSchema.parse({ file_id: "f_1", mime: "image/jpeg", size: -1 }),
+    ).toThrow();
+  });
+});
+
+describe("AuditEntrySchema", () => {
+  it("round-trips a tripped + blocked entry", () => {
+    const obj = {
+      ts: 1714123456789,
+      message_id: "m_1",
+      flags_tripped: ["drafted_line"],
+      reason: "third sentence is a complete poetic line",
+      blocked: true,
+    };
+    expect(AuditEntrySchema.parse(obj)).toEqual(obj);
+  });
+
+  it("blocked defaults to false (log-only mode)", () => {
+    const obj = {
+      ts: 1714123456789,
+      message_id: "m_1",
+      flags_tripped: ["register_drift"],
+      reason: "drifted into letter prose",
+    };
+    expect(AuditEntrySchema.parse(obj).blocked).toBe(false);
+  });
+
+  it("requires at least one tripped flag", () => {
+    expect(() =>
+      AuditEntrySchema.parse({
+        ts: 1,
+        message_id: "m_1",
+        flags_tripped: [],
+        reason: "x",
+      }),
+    ).toThrow();
+  });
+});
+
+describe("SessionSchema", () => {
+  it("round-trips a full session", () => {
+    const obj = {
+      id: "s_1",
+      recipient: "Grandma",
+      occasion: "80th birthday",
+      form: "poem" as const,
+      guide_id: "documentarian",
+      theme: "warm" as const,
+      photos: [],
+      audit: [],
+      created_at: 1714123456789,
+    };
+    expect(SessionSchema.parse(obj)).toEqual(obj);
+  });
+
+  it("photos and audit default to empty arrays", () => {
+    const obj = {
+      id: "s_1",
+      recipient: "G",
+      occasion: "x",
+      form: "letter",
+      guide_id: "songwriter",
+      theme: "quiet",
+      created_at: 1,
+    };
+    const parsed = SessionSchema.parse(obj);
+    expect(parsed.photos).toEqual([]);
+    expect(parsed.audit).toEqual([]);
+  });
+
+  it("rejects invalid form", () => {
+    expect(() =>
+      SessionSchema.parse({
+        id: "s_1",
+        recipient: "x",
+        occasion: "x",
+        form: "song",
+        guide_id: "x",
+        theme: "warm",
+        created_at: 1,
+      }),
+    ).toThrow();
+  });
+});
+
+describe("TurnSchema", () => {
+  it("round-trips with phrases_held", () => {
+    const obj = {
+      id: "t_1",
+      session_id: "s_1",
+      role: "user" as const,
+      text: "Her hands always smelled like garlic and orange peel.",
+      ts: 1,
+      phrases_held: ["garlic and orange peel"],
+    };
+    expect(TurnSchema.parse(obj)).toEqual(obj);
+  });
+
+  it("round-trips without phrases_held", () => {
+    const obj = {
+      id: "t_1",
+      session_id: "s_1",
+      role: "guide" as const,
+      text: "What did her hands actually do?",
+      ts: 1,
+    };
+    expect(TurnSchema.parse(obj)).toEqual(obj);
+  });
+});
+
+describe("ProvenanceLineSchema", () => {
+  it("round-trips each match kind", () => {
+    for (const match of ["exact", "fuzzy", "none"] as const) {
+      const obj = {
+        line: "her hands always smelled like garlic",
+        source_turn_id: "t_1",
+        source_text: "her hands always smelled like garlic and orange peel",
+        match,
+      };
+      expect(ProvenanceLineSchema.parse(obj)).toEqual(obj);
+    }
+  });
+});
+
+describe("ArtifactSchema", () => {
+  it("round-trips a poem artifact with provenance", () => {
+    const obj = {
+      session_id: "s_1",
+      text: "her hands\nsmelled like garlic\nand orange peel",
+      provenance: [
+        {
+          line: "her hands",
+          source_turn_id: "t_1",
+          source_text: "her hands always smelled like garlic and orange peel",
+          match: "exact" as const,
+        },
+      ],
+      byline_pct: 100,
+      created_at: 1714123456789,
+    };
+    expect(ArtifactSchema.parse(obj)).toEqual(obj);
+  });
+
+  it("rejects byline_pct > 100", () => {
+    expect(() =>
+      ArtifactSchema.parse({
+        session_id: "s_1",
+        text: "x",
+        provenance: [],
+        byline_pct: 150,
+        created_at: 1,
+      }),
+    ).toThrow();
+  });
+
+  it("rejects negative byline_pct", () => {
+    expect(() =>
+      ArtifactSchema.parse({
+        session_id: "s_1",
+        text: "x",
+        provenance: [],
+        byline_pct: -1,
+        created_at: 1,
+      }),
+    ).toThrow();
+  });
+});
+
+describe("CritiqueCardSchema", () => {
+  it("round-trips each kind", () => {
+    for (const kind of ["cliche", "question", "verified"] as const) {
+      const obj = { kind, body: "..." };
+      expect(CritiqueCardSchema.parse(obj)).toEqual(obj);
+    }
+  });
+
+  it("round-trips with optional line_ref", () => {
+    const obj = {
+      kind: "verified" as const,
+      line_ref: "line-3",
+      body: "all words yours",
+    };
+    expect(CritiqueCardSchema.parse(obj)).toEqual(obj);
+  });
+
+  it("rejects empty body", () => {
+    expect(() =>
+      CritiqueCardSchema.parse({ kind: "cliche", body: "" }),
+    ).toThrow();
+  });
+});


### PR DESCRIPTION
## Closes #15

Single typed module everyone imports from. Zod schemas as source of truth, inferred TS types alongside — same style as `lib/guides/schema.ts`.

### Exports (all from `lib/types/session.ts`)
- `Theme` / `ThemeSchema` — `'cute' | 'warm' | 'quiet' | 'noir' | 'gothic'`
- `Form` / `FormSchema` — `'poem' | 'letter'` (v1 scope per DESIGN.md §4; widen later if needed)
- `PhotoMeta` / `PhotoMetaSchema` — `{ file_id, mime, size, subject?, setting?, mood? }`
- `AuditEntry` / `AuditEntrySchema` — `{ ts, message_id, flags_tripped[], reason, blocked }`
- `Session` / `SessionSchema` — `{ id, recipient, occasion, form, guide_id, theme, photos[], audit[], created_at }`
- `TurnRole` / `TurnRoleSchema` + `Turn` / `TurnSchema` — `{ id, session_id, role, text, ts, phrases_held? }`
- `ProvenanceMatch` / `ProvenanceMatchSchema` + `ProvenanceLine` / `ProvenanceLineSchema`
- `Artifact` / `ArtifactSchema`
- `CritiqueKind` / `CritiqueKindSchema` + `CritiqueCard` / `CritiqueCardSchema`

### Acceptance (issue #15)
- [x] `lib/types/session.ts` exports all 7 specified types
- [x] All exports are pure types or Zod schemas (consistent with `lib/guides/schema.ts`)
- [x] At least one round-trip unit test per Zod schema (21 tests total)
- [x] No runtime deps beyond `zod`

### Notes for downstream
- `Session.photos` and `Session.audit` default to `[]` so a freshly created session can omit them.
- `AuditEntry.blocked` defaults to `false` — supports the log-only audit mode flagged in DESIGN.md as the #9 mitigation. `flags_tripped` requires at least one entry (an audit is only logged when a flag fires).
- `byline_pct` is constrained to `[0, 100]`; out-of-range inputs throw at parse time.
- `phrases_held?` on Turn is optional and only populated by the spine extractor (#6) for user turns whose phrases became spine candidates.

### Cross-team handoffs
- `@PruthviVKadam` (#2, #5, #8, #11) — imports `Session`, `Turn`, `Artifact`, `ProvenanceLine`, `CritiqueCard` for UI rendering.
- self (#6, #9, #12) — emits `Session` / `Turn` / `Artifact` / `ProvenanceLine` from API routes.
- `@d3v07` (#4, #7, #10) — emits `PhotoMeta` and uses `Theme` for the storyboard.

### Gates
- `tsc --noEmit` ✓
- `vitest run` — 34/34 across all suites
- `next lint` ✓

### Out of scope
Implementations that emit/consume these types — those land in their respective issues.