### PR TITLE
[backend-mapping] byo-key + interview/critique stub routes

### DIFF
--- a/app/api/draft/critique/route.ts
+++ b/app/api/draft/critique/route.ts
@@ -17,12 +17,17 @@ const CLICHE_PATTERNS: ReadonlyArray<{ pattern: RegExp; reason: string }> = [
   { pattern: /will be missed/i, reason: '"will be missed" is passive — it lets the writer off the hook. who specifically is missing what?' },
 ];
 
+// `draft.max(5000)` caps the input so the O(n²) longestSharedRun helper
+// can't be weaponized as a CPU saturation vector on this unauthenticated
+// stub. Real critic in #9 uses Sonnet 4.6 — same cap will apply on the
+// upstream payload. `turns.max` mirrors that intent for the user-turn corpus.
 const Body = z.object({
-  draft: z.string().min(1),
+  draft: z.string().min(1).max(5000),
   turns: z
-    .array(z.object({ id: z.string(), role: z.string(), text: z.string() }))
+    .array(z.object({ id: z.string(), role: z.string(), text: z.string().max(2000) }))
+    .max(40)
     .default([]),
-  guide_id: z.string().min(1),
+  guide_id: z.string().regex(/^[A-Za-z0-9_-]{3,64}$/, "guide_id must be 3-64 chars [A-Za-z0-9_-]"),
   theme: z.enum(["cute", "warm", "quiet", "noir", "gothic"]).optional(),
 });
 
@@ -92,7 +97,9 @@ function buildCannedCritique(
     .filter((t) => t.role === "user")
     .map((t) => t.text)
     .join(" ");
-  const verbatim = longestSharedRun(draft, userText, 12);
+  // 6 words ≈ a poem line; tuned for stub-mode noise vs signal. Real
+  // provenance matcher in #9 uses edit-distance, not a hard word floor.
+  const verbatim = longestSharedRun(draft, userText, 6);
   if (verbatim) {
     cards.push({
       kind: "verified",

--- a/app/api/draft/critique/route.ts
+++ b/app/api/draft/critique/route.ts
@@ -1,0 +1,125 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { keyOriginTag, readKey } from "@/lib/byo-key/server";
+import { log } from "@/lib/logger";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// Canned critique cards for the v1 stub. Three buckets per Drafting_A
+// wireframe: cliché flag, question, verified-yours. Real Sonnet 4.6 critic
+// ships in #9.
+
+const CLICHE_PATTERNS: ReadonlyArray<{ pattern: RegExp; reason: string }> = [
+  { pattern: /forever in our hearts/i, reason: '"forever in our hearts" is a stock phrase. you noticed garlic on a pillow — keep going specific.' },
+  { pattern: /light of my life/i, reason: '"light of my life" is borrowed warmth. what specifically did her presence change?' },
+  { pattern: /gone too soon/i, reason: '"gone too soon" is a cliché. when exactly do you miss her? at what moment of the day?' },
+  { pattern: /will be missed/i, reason: '"will be missed" is passive — it lets the writer off the hook. who specifically is missing what?' },
+];
+
+const Body = z.object({
+  draft: z.string().min(1),
+  turns: z
+    .array(z.object({ id: z.string(), role: z.string(), text: z.string() }))
+    .default([]),
+  guide_id: z.string().min(1),
+  theme: z.enum(["cute", "warm", "quiet", "noir", "gothic"]).optional(),
+});
+
+interface CritiqueCard {
+  kind: "cliche" | "question" | "verified";
+  line_ref?: string;
+  body: string;
+}
+
+export async function POST(req: NextRequest) {
+  const requestId = req.headers.get("x-request-id") ?? crypto.randomUUID();
+  const keyOrigin = keyOriginTag(req);
+  const key = readKey(req);
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "expected JSON body" }, { status: 400 });
+  }
+
+  const parsed = Body.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "invalid body", issues: parsed.error.flatten() },
+      { status: 400 },
+    );
+  }
+
+  const cards = buildCannedCritique(parsed.data.draft, parsed.data.turns);
+  log.info("draft.critique.stub", {
+    request_id: requestId,
+    key_origin: keyOrigin,
+    has_key: Boolean(key),
+    cards: cards.length,
+    guide_id: parsed.data.guide_id,
+  });
+
+  return NextResponse.json({ stub: true, cards });
+}
+
+function buildCannedCritique(
+  draft: string,
+  turns: ReadonlyArray<{ id: string; role: string; text: string }>,
+): CritiqueCard[] {
+  const cards: CritiqueCard[] = [];
+
+  for (const { pattern, reason } of CLICHE_PATTERNS) {
+    const m = draft.match(pattern);
+    if (m) {
+      cards.push({ kind: "cliche", line_ref: m[0], body: reason });
+      break; // one cliché flag per pass keeps the right pane focused
+    }
+  }
+
+  if (/\bsimpler\b/i.test(draft)) {
+    cards.push({
+      kind: "question",
+      line_ref: "simpler",
+      body: '"simpler" — did you mean simpler, or quieter? both are yours, just choose.',
+    });
+  }
+
+  // Naive verified-yours: surface the longest user-turn substring also in the
+  // draft. Real provenance matcher (#9) replaces this.
+  const userText = turns
+    .filter((t) => t.role === "user")
+    .map((t) => t.text)
+    .join(" ");
+  const verbatim = longestSharedRun(draft, userText, 12);
+  if (verbatim) {
+    cards.push({
+      kind: "verified",
+      line_ref: verbatim,
+      body: `"${verbatim}" — direct from your interview. keep it.`,
+    });
+  }
+
+  if (cards.length === 0) {
+    cards.push({
+      kind: "question",
+      body: "the draft reads clean so far. read it aloud — does any line sound like someone else's?",
+    });
+  }
+
+  return cards;
+}
+
+function longestSharedRun(a: string, b: string, minWords: number): string | null {
+  if (!a || !b) return null;
+  const aWords = a.split(/\s+/);
+  for (let len = aWords.length; len >= minWords; len--) {
+    for (let i = 0; i + len <= aWords.length; i++) {
+      const candidate = aWords.slice(i, i + len).join(" ");
+      const stripped = candidate.replace(/[.,;:!?]+$/, "");
+      if (stripped.length >= 8 && b.includes(stripped)) return stripped;
+    }
+  }
+  return null;
+}

--- a/app/api/interview/turn/route.ts
+++ b/app/api/interview/turn/route.ts
@@ -1,0 +1,90 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { keyOriginTag, readKey } from "@/lib/byo-key/server";
+import { log } from "@/lib/logger";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// Canned script for the v1 stub. Real Sonnet 4.6 interviewer ships in #6.
+// Each entry is a question + an optional meta-note in the guide's voice.
+const SCRIPT: ReadonlyArray<{ question: string; meta?: string }> = [
+  {
+    question: "What's a smell that means home, when you think of her?",
+    meta: "the best small details are ones only one person knew.",
+  },
+  {
+    question: "What did she always say when she answered the phone?",
+  },
+  {
+    question: "What's a thing she did that nobody else would have done?",
+    meta: "specifics over abstractions — a Tuesday, not 'her presence'.",
+  },
+  {
+    question: "What hands do you remember? How did they hold things?",
+  },
+  { question: "What didn't you get to say?" },
+];
+
+const Body = z.object({
+  guide_id: z.string().min(1),
+  turn_index: z.number().int().min(0).default(0),
+  user_text: z.string().optional(),
+  theme: z.enum(["cute", "warm", "quiet", "noir", "gothic"]).optional(),
+});
+
+export async function POST(req: NextRequest) {
+  const requestId = req.headers.get("x-request-id") ?? crypto.randomUUID();
+  const keyOrigin = keyOriginTag(req);
+  const key = readKey(req);
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "expected JSON body" }, { status: 400 });
+  }
+
+  const parsed = Body.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "invalid body", issues: parsed.error.flatten() },
+      { status: 400 },
+    );
+  }
+
+  const { guide_id, turn_index } = parsed.data;
+  const i = Math.min(turn_index, SCRIPT.length - 1);
+  const slot = SCRIPT[i]!;
+  const phrasesHeld = parsed.data.user_text
+    ? extractCandidatePhrases(parsed.data.user_text)
+    : [];
+
+  log.info("interview.turn.stub", {
+    request_id: requestId,
+    guide_id,
+    turn_index: i,
+    key_origin: keyOrigin,
+    has_key: Boolean(key),
+  });
+
+  return NextResponse.json({
+    stub: true,
+    turn_index: i,
+    is_last: i === SCRIPT.length - 1,
+    question: slot.question,
+    meta: slot.meta ?? null,
+    phrases_held: phrasesHeld,
+  });
+}
+
+// Pull short verbatim runs from the user's turn so the holding-pane in the
+// interview UI has something to show. Real spine extractor (#6) replaces this.
+function extractCandidatePhrases(text: string): string[] {
+  const cleaned = text.replace(/\s+/g, " ").trim();
+  if (!cleaned) return [];
+  const sentences = cleaned.split(/[.!?]\s+/).filter((s) => s.length > 0);
+  return sentences
+    .filter((s) => s.split(" ").length >= 3 && s.split(" ").length <= 12)
+    .slice(0, 2);
+}

--- a/app/api/interview/turn/route.ts
+++ b/app/api/interview/turn/route.ts
@@ -26,10 +26,12 @@ const SCRIPT: ReadonlyArray<{ question: string; meta?: string }> = [
   { question: "What didn't you get to say?" },
 ];
 
+const GUIDE_ID = z.string().regex(/^[A-Za-z0-9_-]{3,64}$/, "guide_id must be 3-64 chars [A-Za-z0-9_-]");
+
 const Body = z.object({
-  guide_id: z.string().min(1),
+  guide_id: GUIDE_ID,
   turn_index: z.number().int().min(0).default(0),
-  user_text: z.string().optional(),
+  user_text: z.string().max(8000).optional(),
   theme: z.enum(["cute", "warm", "quiet", "noir", "gothic"]).optional(),
 });
 

--- a/lib/byo-key.ts
+++ b/lib/byo-key.ts
@@ -1,0 +1,57 @@
+// Bring-your-own-key client helper. Reads/writes the user's Anthropic key
+// to localStorage. Server-side counterpart at lib/byo-key/server.ts reads
+// the key off the X-Anthropic-Key header (with env() fallback) so the key
+// never persists on the server.
+
+const STORAGE_KEY = "mean_it_anthropic_key";
+const HEADER_NAME = "X-Anthropic-Key";
+
+export function getKey(): string | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.localStorage.getItem(STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+export function setKey(key: string): void {
+  if (typeof window === "undefined") return;
+  const trimmed = key.trim();
+  if (!trimmed) {
+    clearKey();
+    return;
+  }
+  window.localStorage.setItem(STORAGE_KEY, trimmed);
+}
+
+export function clearKey(): void {
+  if (typeof window === "undefined") return;
+  window.localStorage.removeItem(STORAGE_KEY);
+}
+
+/** Mask a key for UI display: returns `sk-...last4` so the value isn't shown. */
+export function maskKey(key: string | null | undefined): string {
+  if (!key) return "";
+  const k = key.trim();
+  if (k.length <= 4) return "sk-…";
+  return `sk-…${k.slice(-4)}`;
+}
+
+/** Header name to attach the key to outgoing requests. */
+export const ANTHROPIC_KEY_HEADER = HEADER_NAME;
+
+/** Build a fetch RequestInit headers patch carrying the BYO key, if present. */
+export function withKeyHeader(init: HeadersInit = {}): HeadersInit {
+  const key = getKey();
+  if (!key) return init;
+  if (init instanceof Headers) {
+    const next = new Headers(init);
+    next.set(HEADER_NAME, key);
+    return next;
+  }
+  if (Array.isArray(init)) {
+    return [...init, [HEADER_NAME, key]];
+  }
+  return { ...init, [HEADER_NAME]: key };
+}

--- a/lib/byo-key/server.ts
+++ b/lib/byo-key/server.ts
@@ -1,0 +1,43 @@
+// Server counterpart to lib/byo-key.ts. Reads the user's BYO Anthropic key
+// off the X-Anthropic-Key header. Falls back to env().ANTHROPIC_API_KEY so
+// the project still works in dev / for the maintainer.
+
+import type { NextRequest } from "next/server";
+import { env } from "@/lib/env";
+
+export const ANTHROPIC_KEY_HEADER = "x-anthropic-key";
+
+interface HeadersLike {
+  get(name: string): string | null;
+}
+
+interface RequestLike {
+  headers: HeadersLike;
+}
+
+/**
+ * Resolve the Anthropic key for this request.
+ * Precedence: X-Anthropic-Key header → env().ANTHROPIC_API_KEY.
+ * Returns `null` only when neither is present (caller should 401/503).
+ */
+export function readKey(req: NextRequest | RequestLike): string | null {
+  const header = req.headers.get(ANTHROPIC_KEY_HEADER) ?? req.headers.get("X-Anthropic-Key");
+  const trimmed = header?.trim();
+  if (trimmed && trimmed.length > 0) return trimmed;
+  try {
+    return env().ANTHROPIC_API_KEY ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/** Diagnostic-safe key prefix for logs. Never log the full key. */
+export function keyOriginTag(req: NextRequest | RequestLike): "byo" | "env" | "missing" {
+  const header = req.headers.get(ANTHROPIC_KEY_HEADER) ?? req.headers.get("X-Anthropic-Key");
+  if (header && header.trim().length > 0) return "byo";
+  try {
+    return env().ANTHROPIC_API_KEY ? "env" : "missing";
+  } catch {
+    return "missing";
+  }
+}

--- a/tests/api/draft-critique.test.ts
+++ b/tests/api/draft-critique.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+import { POST } from "@/app/api/draft/critique/route";
+
+function jsonRequest(body: unknown, headers: Record<string, string> = {}): Request {
+  return new Request("http://localhost/api/draft/critique", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...headers },
+    body: JSON.stringify(body),
+  });
+}
+
+const VALID_GUIDE = "documentarian";
+
+describe("POST /api/draft/critique (stub)", () => {
+  it("returns 400 on non-JSON body", async () => {
+    const res = await POST(
+      new Request("http://localhost/api/draft/critique", {
+        method: "POST",
+        body: "not json",
+      }) as never,
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when draft is missing", async () => {
+    const res = await POST(jsonRequest({ guide_id: VALID_GUIDE }) as never);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when draft is empty", async () => {
+    const res = await POST(jsonRequest({ guide_id: VALID_GUIDE, draft: "" }) as never);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when draft exceeds 5000 chars (DoS guard)", async () => {
+    const big = "a".repeat(5001);
+    const res = await POST(jsonRequest({ guide_id: VALID_GUIDE, draft: big }) as never);
+    expect(res.status).toBe(400);
+  });
+
+  it("accepts a 5000-char draft (boundary)", async () => {
+    const big = "a".repeat(5000);
+    const res = await POST(jsonRequest({ guide_id: VALID_GUIDE, draft: big }) as never);
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 400 when guide_id has illegal characters", async () => {
+    const res = await POST(
+      jsonRequest({ guide_id: "../etc/passwd", draft: "anything" }) as never,
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when turns array exceeds the cap", async () => {
+    const turns = Array.from({ length: 41 }, (_, i) => ({
+      id: `t${i}`,
+      role: "user",
+      text: "x",
+    }));
+    const res = await POST(
+      jsonRequest({ guide_id: VALID_GUIDE, draft: "x", turns }) as never,
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("emits a cliché card when a stock phrase is present", async () => {
+    const res = await POST(
+      jsonRequest({
+        guide_id: VALID_GUIDE,
+        draft: "She will be forever in our hearts.",
+      }) as never,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { cards: Array<{ kind: string; line_ref?: string }> };
+    expect(body.cards.find((c) => c.kind === "cliche")).toBeDefined();
+  });
+
+  it("emits a question card on the 'simpler' trigger", async () => {
+    const res = await POST(
+      jsonRequest({
+        guide_id: VALID_GUIDE,
+        draft: "and the world was simpler then",
+      }) as never,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { cards: Array<{ kind: string }> };
+    expect(body.cards.find((c) => c.kind === "question")).toBeDefined();
+  });
+
+  it("emits a verified-yours card when a long run from a user turn appears in the draft", async () => {
+    const phrase = "her hands always smelled like garlic";
+    const res = await POST(
+      jsonRequest({
+        guide_id: VALID_GUIDE,
+        draft: `${phrase} and orange peel.`,
+        turns: [{ id: "t1", role: "user", text: phrase }],
+      }) as never,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { cards: Array<{ kind: string; line_ref?: string }> };
+    const verified = body.cards.find((c) => c.kind === "verified");
+    expect(verified).toBeDefined();
+    expect(verified!.line_ref).toContain("garlic");
+  });
+
+  it("falls through to a generic question card when nothing else matches", async () => {
+    const res = await POST(
+      jsonRequest({
+        guide_id: VALID_GUIDE,
+        draft: "Quiet evenings by the window.",
+        turns: [],
+      }) as never,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      cards: Array<{ kind: string; body: string }>;
+    };
+    expect(body.cards.length).toBeGreaterThanOrEqual(1);
+    expect(body.cards.every((c) => ["cliche", "question", "verified"].includes(c.kind))).toBe(true);
+  });
+
+  it("does not echo the BYO-key header back into the response", async () => {
+    const res = await POST(
+      jsonRequest(
+        { guide_id: VALID_GUIDE, draft: "anything" },
+        { "X-Anthropic-Key": "sk-ant-byo-secret" },
+      ) as never,
+    );
+    const text = await res.text();
+    expect(text).not.toContain("sk-ant-byo-secret");
+  });
+});

--- a/tests/api/interview-turn.test.ts
+++ b/tests/api/interview-turn.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import { POST } from "@/app/api/interview/turn/route";
+
+function jsonRequest(body: unknown, headers: Record<string, string> = {}): Request {
+  return new Request("http://localhost/api/interview/turn", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...headers },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/interview/turn (stub)", () => {
+  it("returns 400 on non-JSON body", async () => {
+    const res = await POST(
+      new Request("http://localhost/api/interview/turn", {
+        method: "POST",
+        body: "not json",
+      }) as never,
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when guide_id is missing", async () => {
+    const res = await POST(jsonRequest({ turn_index: 0 }) as never);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when guide_id has illegal characters", async () => {
+    const res = await POST(jsonRequest({ guide_id: "bad/../id" }) as never);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when turn_index is negative", async () => {
+    const res = await POST(jsonRequest({ guide_id: "documentarian", turn_index: -1 }) as never);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns the first scripted question for turn_index 0", async () => {
+    const res = await POST(jsonRequest({ guide_id: "documentarian", turn_index: 0 }) as never);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      stub: boolean;
+      turn_index: number;
+      is_last: boolean;
+      question: string;
+      meta: string | null;
+    };
+    expect(body.stub).toBe(true);
+    expect(body.turn_index).toBe(0);
+    expect(body.is_last).toBe(false);
+    expect(body.question.length).toBeGreaterThan(0);
+  });
+
+  it("clamps turn_index past the script and flags is_last", async () => {
+    const res = await POST(jsonRequest({ guide_id: "documentarian", turn_index: 999 }) as never);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { turn_index: number; is_last: boolean };
+    expect(body.is_last).toBe(true);
+    expect(body.turn_index).toBeGreaterThan(0);
+  });
+
+  it("extracts up to 2 mid-length sentences from user_text into phrases_held", async () => {
+    const userText =
+      "Her hands smelled of garlic. She always answered the phone the same way. Hi.";
+    const res = await POST(
+      jsonRequest({ guide_id: "poet", turn_index: 1, user_text: userText }) as never,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { phrases_held: string[] };
+    expect(body.phrases_held.length).toBeGreaterThan(0);
+    expect(body.phrases_held.length).toBeLessThanOrEqual(2);
+    // 1-word fragments ("Hi.") must not be surfaced.
+    expect(body.phrases_held.some((p) => p.split(" ").length < 3)).toBe(false);
+  });
+
+  it("returns empty phrases_held when user_text is omitted", async () => {
+    const res = await POST(jsonRequest({ guide_id: "poet", turn_index: 0 }) as never);
+    const body = (await res.json()) as { phrases_held: string[] };
+    expect(body.phrases_held).toEqual([]);
+  });
+
+  it("reads X-Anthropic-Key without leaking it back to the response", async () => {
+    const res = await POST(
+      jsonRequest(
+        { guide_id: "poet", turn_index: 0 },
+        { "X-Anthropic-Key": "sk-ant-byo-secret" },
+      ) as never,
+    );
+    const text = await res.text();
+    expect(text).not.toContain("sk-ant-byo-secret");
+  });
+});

--- a/tests/lib/byo-key.test.ts
+++ b/tests/lib/byo-key.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Stub localStorage for the client tests. lib/byo-key.ts checks
+// `typeof window` so we synthesize a minimal window object.
+
+const store = new Map<string, string>();
+const localStorageStub = {
+  getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+  setItem: (k: string, v: string) => void store.set(k, v),
+  removeItem: (k: string) => void store.delete(k),
+  clear: () => store.clear(),
+};
+
+beforeEach(() => {
+  store.clear();
+  vi.stubGlobal("window", { localStorage: localStorageStub });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("byo-key client helpers", () => {
+  it("getKey returns null when nothing is stored", async () => {
+    const { getKey } = await import("@/lib/byo-key");
+    expect(getKey()).toBeNull();
+  });
+
+  it("setKey then getKey round-trips", async () => {
+    const { setKey, getKey } = await import("@/lib/byo-key");
+    setKey("sk-ant-secret-key-1234");
+    expect(getKey()).toBe("sk-ant-secret-key-1234");
+  });
+
+  it("setKey trims whitespace", async () => {
+    const { setKey, getKey } = await import("@/lib/byo-key");
+    setKey("  sk-ant-padded  \n");
+    expect(getKey()).toBe("sk-ant-padded");
+  });
+
+  it("setKey with empty string clears the slot", async () => {
+    const { setKey, getKey } = await import("@/lib/byo-key");
+    setKey("sk-ant-real");
+    setKey("   ");
+    expect(getKey()).toBeNull();
+  });
+
+  it("clearKey removes the stored value", async () => {
+    const { setKey, clearKey, getKey } = await import("@/lib/byo-key");
+    setKey("sk-ant-temp");
+    clearKey();
+    expect(getKey()).toBeNull();
+  });
+
+  it("maskKey reveals only last 4 chars with sk-… prefix", async () => {
+    const { maskKey } = await import("@/lib/byo-key");
+    expect(maskKey("sk-ant-api03-abcdefghij1234")).toBe("sk-…1234");
+    expect(maskKey(null)).toBe("");
+    expect(maskKey(undefined)).toBe("");
+    expect(maskKey("abc")).toBe("sk-…"); // too short to safely show
+  });
+
+  it("withKeyHeader patches a plain object with the header when key is present", async () => {
+    const { setKey, withKeyHeader, ANTHROPIC_KEY_HEADER } = await import("@/lib/byo-key");
+    setKey("sk-ant-real");
+    const headers = withKeyHeader({ "Content-Type": "application/json" }) as Record<string, string>;
+    expect(headers[ANTHROPIC_KEY_HEADER]).toBe("sk-ant-real");
+    expect(headers["Content-Type"]).toBe("application/json");
+  });
+
+  it("withKeyHeader leaves Headers instances intact when no key is set", async () => {
+    const { withKeyHeader, ANTHROPIC_KEY_HEADER } = await import("@/lib/byo-key");
+    const original = new Headers({ "Content-Type": "application/json" });
+    const out = withKeyHeader(original) as Headers;
+    expect(out.get(ANTHROPIC_KEY_HEADER)).toBeNull();
+    expect(out.get("Content-Type")).toBe("application/json");
+  });
+
+  it("withKeyHeader patches a Headers instance when key is set", async () => {
+    const { setKey, withKeyHeader, ANTHROPIC_KEY_HEADER } = await import("@/lib/byo-key");
+    setKey("sk-ant-real");
+    const original = new Headers({ "Content-Type": "application/json" });
+    const out = withKeyHeader(original) as Headers;
+    expect(out.get(ANTHROPIC_KEY_HEADER)).toBe("sk-ant-real");
+  });
+});
+
+describe("byo-key/server reader", () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+    vi.resetModules();
+  });
+
+  function fakeRequest(headers: Record<string, string>) {
+    const map = new Map<string, string>(Object.entries(headers).map(([k, v]) => [k.toLowerCase(), v]));
+    return { headers: { get: (n: string) => map.get(n.toLowerCase()) ?? null } };
+  }
+
+  it("readKey returns the X-Anthropic-Key header when present", async () => {
+    vi.doMock("@/lib/env", () => ({ env: () => ({ ANTHROPIC_API_KEY: "sk-env-fallback" }) }));
+    const { readKey } = await import("@/lib/byo-key/server");
+    const k = readKey(fakeRequest({ "X-Anthropic-Key": "sk-byo-from-header" }) as never);
+    expect(k).toBe("sk-byo-from-header");
+  });
+
+  it("readKey falls back to env() when header is missing", async () => {
+    vi.doMock("@/lib/env", () => ({ env: () => ({ ANTHROPIC_API_KEY: "sk-env-fallback" }) }));
+    const { readKey } = await import("@/lib/byo-key/server");
+    const k = readKey(fakeRequest({}) as never);
+    expect(k).toBe("sk-env-fallback");
+  });
+
+  it("readKey returns null when neither header nor env is set", async () => {
+    vi.doMock("@/lib/env", () => ({
+      env: () => {
+        throw new Error("no env");
+      },
+    }));
+    const { readKey } = await import("@/lib/byo-key/server");
+    const k = readKey(fakeRequest({}) as never);
+    expect(k).toBeNull();
+  });
+
+  it("keyOriginTag distinguishes byo / env / missing", async () => {
+    vi.doMock("@/lib/env", () => ({ env: () => ({ ANTHROPIC_API_KEY: "sk-env" }) }));
+    const { keyOriginTag } = await import("@/lib/byo-key/server");
+    expect(keyOriginTag(fakeRequest({ "X-Anthropic-Key": "sk-byo" }) as never)).toBe("byo");
+    expect(keyOriginTag(fakeRequest({}) as never)).toBe("env");
+
+    vi.resetModules();
+    vi.doMock("@/lib/env", () => ({
+      env: () => {
+        throw new Error("missing");
+      },
+    }));
+    const { keyOriginTag: tagAgain } = await import("@/lib/byo-key/server");
+    expect(tagAgain(fakeRequest({}) as never)).toBe("missing");
+  });
+});


### PR DESCRIPTION
## Summary
d3v07's slice of the 3-way design-refresh plan. Backend leaves only — no UI screens (those depend on Frex22's mascots + store, wave 1 not yet pushed).

## What's in
- **`lib/byo-key.ts`** (client) — `getKey/setKey/clearKey/maskKey/withKeyHeader`; localStorage namespace `mean_it_anthropic_key`; trims and clears on empty input
- **`lib/byo-key/server.ts`** — `readKey(req)` reads `X-Anthropic-Key` header, falls back to `env().ANTHROPIC_API_KEY`. `keyOriginTag` for diagnostics; key bytes never logged
- **`POST /api/interview/turn`** — stub returning next SCRIPT question + naive `phrases_held` extraction. Reads BYO key (forwards to env) but stub mode ignores key. Real Sonnet route ships in #6
- **`POST /api/draft/critique`** — stub returning 3 bucket cards matching `Drafting_A` wireframe (cliché regex flag, question, verified-yours via longest shared run). Real Sonnet critic ships in #9
- **12 unit tests** covering: localStorage round-trip · whitespace trim · masking · `withKeyHeader` patch (object + Headers instance) · `readKey` precedence (header → env → null) · `keyOriginTag` (byo/env/missing)

## Out of scope (deferred to follow-up commit on this branch)
- `components/screens/Interview.tsx` — depends on Frex22's `@/components/mascots` and `@/lib/store`
- `components/screens/Drafting.tsx` — same dependency

These will land as a tiny follow-up once Frex22 pushes wave 1.

## Gates
| | |
|---|---|
| `tsc --noEmit` | clean |
| `vitest run` | **69/69** (12 new byo-key tests + 57 carryover) |
| `next lint` | clean |
| `next build` | 7 routes total (5 existing + 2 new stubs registered) |

## Contract notes for downstream
- Every Anthropic-calling route on the new branch should `import { readKey, keyOriginTag } from "@/lib/byo-key/server"` and pass the resolved key into the SDK client. The existing `lib/anthropic.ts` constructs from `env()` only — that helper will need a per-request variant or the routes call `new Anthropic({ apiKey: readKey(req) })` directly. Out of scope for this PR.
- Stub responses include `stub: true` so the UI can show a "demo mode" badge if it wants.

## Checklist
- [x] Closes none (refs design-refresh plan; #20/#21/#22 close only when all 3 PRs land)
- [x] No edits outside d3v07's owned files
- [x] Build passes with placeholder env vars