### PR TITLE
feat: design refresh — letterpress identity (Closes #2 #20 #21 #22)

### DIFF
--- a/app/api/moment/parse/route.ts
+++ b/app/api/moment/parse/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from "next/server";
+
+export async function POST(req: Request) {
+  // Stub for sprint 1. Later this will call Claude.
+  // We can pretend to read the request body, but for now we just return a canned response.
+  
+  return NextResponse.json({
+    recipient: "Mom",
+    occasion: "Birthday",
+    when: "Tomorrow",
+    tone: "Warm",
+  });
+}

--- a/app/api/spine/route.ts
+++ b/app/api/spine/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from "next/server";
+import { SCRIPT } from "@/lib/demo";
+
+export const runtime = "nodejs";
+
+/**
+ * POST /api/spine — Spine extractor (stub).
+ *
+ * Sprint-1 (this branch): returns the canonical eulogy SCRIPT's spine
+ * candidates + structure. Ignores the request body.
+ *
+ * Sprint-2 contract:
+ *   request:  { turns: Turn[]; guide_id: string; form: Form }
+ *   response: { candidates: DemoSpineCandidate[]; structure: DemoStructureMovement[] }
+ *
+ * Real implementation = Haiku 4.5 returning verbatim substrings of the
+ * user-typed turns + a structure proposal calibrated to the active form.
+ */
+export async function POST(): Promise<Response> {
+  return NextResponse.json(
+    {
+      candidates: SCRIPT.spineCandidates,
+      structure: SCRIPT.structure,
+    },
+    { headers: { "X-Mean-It-Stub": "1" } },
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,93 +1,897 @@
-@import url("https://fonts.googleapis.com/css2?family=Lora:ital,wght@0,400;0,500;0,600;1,400&family=DM+Sans:wght@400;500;600&family=Playfair+Display:ital,wght@0,400;0,600;0,700;1,400&family=Space+Grotesk:wght@400;500;600&display=swap");
-
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
+/* ─────────────────────────────────────────────────────────────
+   Mean It — letterpress / stationery identity.
+   Five themes (cute → warm → quiet → noir → gothic).
+   Visual vocabulary: deckle paper, postal motifs, debossed plates,
+   wax seals, tape, ink-block stamps. Type: editorial display + mono UI.
+   ───────────────────────────────────────────────────────────── */
+
 :root {
-  /* Warm amber defaults — overridden at runtime by applyTheme() */
-  --bg: #faf8f4;
-  --surface: #f2ede4;
-  --border: #d3d1c7;
-  --text-primary: #2c2420;
-  --text-muted: #7a6e66;
-  --accent: #ef9f27;
-  --accent-dark: #ba7517;
-  --accent-soft: #fde8b8;
-  --radius-card: 16px;
-  --radius-btn: 9999px;
-  --font-serif: 'Lora', Georgia, serif;
-  --font-sans: 'DM Sans', system-ui, sans-serif;
+  /* default = warm */
+  --t-bg: #ece2cf;
+  --t-paper: #f5ecd9;
+  --t-paper-warm: #ede2c8;
+  --t-paper-shadow: rgba(58, 36, 14, 0.18);
+  --t-paper-highlight: rgba(255, 248, 230, 0.85);
+
+  --t-ink: #1d150c;
+  --t-ink-soft: #4a3a26;
+  --t-ink-faint: rgba(29, 21, 12, 0.46);
+  --t-ink-ghost: rgba(29, 21, 12, 0.14);
+
+  --t-accent: #8b2418;          /* postal red */
+  --t-accent-deep: #5e1810;
+  --t-accent-soft: rgba(139, 36, 24, 0.14);
+  --t-seal: #8b2418;            /* wax seal */
+
+  --t-highlight: #e6c64f;       /* highlighter */
+  --t-verified: #4a6b3a;
+  --t-tape: rgba(212, 184, 130, 0.65);
+
+  --t-display: var(--font-playfair-display), 'Iowan Old Style', Georgia, serif;
+  --t-body: var(--font-eb-garamond), 'Iowan Old Style', Georgia, serif;
+  --t-mono: var(--font-jetbrains-mono), 'IBM Plex Mono', ui-monospace, monospace;
+  --t-hand: var(--font-caveat), cursive;
+  --t-stamp: var(--font-special-elite), 'Courier Prime', 'Courier New', monospace;
+  --t-display-style: italic;
+  --t-display-weight: 600;
+
+  --t-radius: 1px;
+  --t-ornament-color: rgba(139, 36, 24, 0.55);
+  --t-anim-speed: 1;
+
+  /* paper texture, layered */
+  --t-grain: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='320' height='320'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.92' numOctaves='2' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 0.12  0 0 0 0 0.08  0 0 0 0 0.04  0 0 0 0.7 0'/></filter><rect width='100%' height='100%' filter='url(%23n)' opacity='0.55'/></svg>");
+  --t-fibers: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='600' height='600'><filter id='f'><feTurbulence type='turbulence' baseFrequency='0.012 0.4' numOctaves='2' seed='3'/><feColorMatrix values='0 0 0 0 0.18  0 0 0 0 0.10  0 0 0 0 0.04  0 0 0 0.18 0'/></filter><rect width='100%' height='100%' filter='url(%23f)'/></svg>");
 }
 
-@layer base {
-  body {
-    background-color: var(--bg);
-    color: var(--text-primary);
-    font-family: "DM Sans", system-ui, sans-serif;
-    transition: background-color 0.3s ease, color 0.3s ease;
-    margin: 0;
-    overflow-x: hidden;
-  }
-
-  /* Font swap for gothic/edge end */
-  .theme-edge body,
-  .theme-edge {
-    font-family: "Space Grotesk", system-ui, sans-serif;
-  }
-
-  .font-serif {
-    font-family: "Lora", Georgia, serif;
-  }
-
-  .theme-edge .font-serif {
-    font-family: "Playfair Display", Georgia, serif;
-  }
+/* ─────────── theme: cute ─────────── */
+.theme-cute {
+  --t-bg: #fce6e4;
+  --t-paper: #fff2ee;
+  --t-paper-warm: #ffe2dc;
+  --t-paper-shadow: rgba(120, 40, 50, 0.14);
+  --t-paper-highlight: rgba(255, 250, 248, 0.9);
+  --t-ink: #4a2030;
+  --t-ink-soft: #7a4050;
+  --t-ink-faint: rgba(74, 32, 48, 0.46);
+  --t-ink-ghost: rgba(74, 32, 48, 0.13);
+  --t-accent: #d34860;
+  --t-accent-deep: #9a2a3c;
+  --t-accent-soft: rgba(211, 72, 96, 0.16);
+  --t-seal: #d34860;
+  --t-highlight: #ffd66b;
+  --t-verified: #6e8a3e;
+  --t-tape: rgba(255, 200, 180, 0.7);
+  --t-display: var(--font-fraunces), var(--font-playfair-display), Georgia, serif;
+  --t-body: var(--font-eb-garamond), Georgia, serif;
+  --t-display-weight: 700;
+  --t-display-style: normal;
+  --t-radius: 6px;
+  --t-ornament-color: rgba(211, 72, 96, 0.7);
+  --t-anim-speed: 1.6;
 }
 
-@layer utilities {
-  .transition-theme {
-    transition: background-color 0.3s ease, color 0.3s ease, border-color 0.3s ease;
-  }
+/* ─────────── theme: warm (default) ─────────── */
+.theme-warm { /* uses :root values */ }
+
+/* ─────────── theme: quiet ─────────── */
+.theme-quiet {
+  --t-bg: #e7e4d8;
+  --t-paper: #f0ede0;
+  --t-paper-warm: #e6e2d2;
+  --t-paper-shadow: rgba(40, 38, 30, 0.16);
+  --t-paper-highlight: rgba(252, 250, 240, 0.85);
+  --t-ink: #1f1d18;
+  --t-ink-soft: #3e3a30;
+  --t-ink-faint: rgba(31, 29, 24, 0.42);
+  --t-ink-ghost: rgba(31, 29, 24, 0.10);
+  --t-accent: #4a6b3a;
+  --t-accent-deep: #2f4a24;
+  --t-accent-soft: rgba(74, 107, 58, 0.14);
+  --t-seal: #4a6b3a;
+  --t-highlight: #d8c870;
+  --t-verified: #4a6b3a;
+  --t-tape: rgba(190, 180, 150, 0.55);
+  --t-display-weight: 500;
+  --t-radius: 1px;
+  --t-anim-speed: 0.8;
+  --t-ornament-color: rgba(74, 107, 58, 0.6);
 }
 
-/* Floating animations */
-@keyframes fade-in {
-  from {
-    opacity: 0;
-    transform: translateY(20px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
+/* ─────────── theme: noir ─────────── */
+.theme-noir {
+  --t-bg: #18140e;
+  --t-paper: #221d14;
+  --t-paper-warm: #2a2418;
+  --t-paper-shadow: rgba(0, 0, 0, 0.55);
+  --t-paper-highlight: rgba(212, 168, 90, 0.10);
+  --t-ink: #ece4d2;
+  --t-ink-soft: #c8bea4;
+  --t-ink-faint: rgba(236, 228, 210, 0.42);
+  --t-ink-ghost: rgba(236, 228, 210, 0.12);
+  --t-accent: #d4a85a;
+  --t-accent-deep: #a07d34;
+  --t-accent-soft: rgba(212, 168, 90, 0.16);
+  --t-seal: #d4a85a;
+  --t-highlight: rgba(212, 168, 90, 0.32);
+  --t-verified: #9eb56c;
+  --t-tape: rgba(140, 110, 60, 0.55);
+  --t-display-weight: 500;
+  --t-radius: 1px;
+  --t-anim-speed: 0.6;
+  --t-ornament-color: rgba(212, 168, 90, 0.7);
 }
 
-@keyframes float-slow {
-  0%, 100% { transform: translateY(0); }
-  50% { transform: translateY(-15px); }
+/* ─────────── theme: gothic ─────────── */
+.theme-gothic {
+  --t-bg: #14111a;
+  --t-paper: #1d1825;
+  --t-paper-warm: #221d2c;
+  --t-paper-shadow: rgba(0, 0, 0, 0.6);
+  --t-paper-highlight: rgba(154, 134, 184, 0.10);
+  --t-ink: #e0dae8;
+  --t-ink-soft: #b8b0c6;
+  --t-ink-faint: rgba(224, 218, 232, 0.42);
+  --t-ink-ghost: rgba(224, 218, 232, 0.12);
+  --t-accent: #b89be0;
+  --t-accent-deep: #7e60a8;
+  --t-accent-soft: rgba(184, 155, 224, 0.16);
+  --t-seal: #b89be0;
+  --t-highlight: rgba(184, 155, 224, 0.32);
+  --t-verified: #9eb56c;
+  --t-tape: rgba(120, 100, 150, 0.45);
+  --t-display: var(--font-playfair-display), Georgia, serif;
+  --t-display-weight: 500;
+  --t-display-style: italic;
+  --t-radius: 1px;
+  --t-anim-speed: 0.4;
+  --t-ornament-color: rgba(184, 155, 224, 0.7);
 }
 
-@keyframes float-drift {
-  0%, 100% { transform: translate(0, 0) rotate(0deg); }
-  25% { transform: translate(5px, -10px) rotate(5deg); }
-  50% { transform: translate(-5px, -20px) rotate(-3deg); }
-  75% { transform: translate(3px, -10px) rotate(2deg); }
+/* ───────────────────────────────────────────────
+   shell + paper
+   ─────────────────────────────────────────────── */
+
+* { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; }
+body {
+  background: var(--t-bg);
+  color: var(--t-ink);
+  font-family: var(--t-body);
+  font-feature-settings: "kern", "liga", "onum";
+  font-size: 17px;
+  line-height: 1.6;
+  min-height: 100vh;
+  transition: background 800ms ease, color 800ms ease;
 }
 
-@keyframes sparkle-pulse {
-  0%, 100% { opacity: 0.3; transform: scale(1); }
-  50% { opacity: 1; transform: scale(1.3); }
+.app {
+  position: relative;
+  min-height: 100vh;
+  background: var(--t-bg);
+  transition: background 800ms ease, color 800ms ease;
 }
 
-.animate-fade-in {
-  animation: fade-in 0.6s ease-out forwards;
+/* paper grain over whole app */
+.grain {
+  position: fixed; inset: 0; pointer-events: none; z-index: 1;
+  background-image: var(--t-grain);
+  opacity: 0.5;
+  mix-blend-mode: multiply;
+}
+.theme-noir .grain, .theme-gothic .grain {
+  opacity: 0.45; mix-blend-mode: screen;
 }
 
-.animate-float-slow {
-  animation: float-slow 6s ease-in-out infinite;
+/* paper fibers: slightly larger texture */
+.app::before {
+  content: ''; position: fixed; inset: 0; pointer-events: none; z-index: 0;
+  background-image: var(--t-fibers);
+  opacity: 0.35;
+  mix-blend-mode: multiply;
+}
+.theme-noir.app::before, .theme-gothic.app::before {
+  mix-blend-mode: screen; opacity: 0.25;
 }
 
-.animate-sparkle {
-  animation: sparkle-pulse 3s ease-in-out infinite;
+.app > * { position: relative; z-index: 2; }
+
+/* ───────────────────────────────────────────────
+   chrome — paper tape header
+   ─────────────────────────────────────────────── */
+
+.chrome {
+  position: sticky; top: 0; z-index: 50;
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 16px 28px 14px;
+  background:
+    linear-gradient(180deg,
+      color-mix(in srgb, var(--t-paper) 92%, transparent) 0%,
+      color-mix(in srgb, var(--t-paper) 88%, transparent) 100%);
+  backdrop-filter: blur(6px);
+  border-bottom: 1px solid var(--t-ink-ghost);
+  font-family: var(--t-mono);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--t-ink-faint);
+  transition: background 800ms ease, border-color 800ms ease, color 800ms ease;
 }
+/* tape strip across the top */
+.chrome::before {
+  content: ''; position: absolute; left: 0; right: 0; top: 0; height: 4px;
+  background:
+    repeating-linear-gradient(90deg,
+      var(--t-tape) 0 14px,
+      color-mix(in srgb, var(--t-tape) 70%, var(--t-ink-soft)) 14px 16px,
+      var(--t-tape) 16px 28px);
+  opacity: 0.55;
+}
+/* ruled line below */
+.chrome::after {
+  content: ''; position: absolute; left: 0; right: 0; bottom: -1px;
+  height: 1px;
+  background:
+    repeating-linear-gradient(90deg,
+      var(--t-ink-faint) 0 6px, transparent 6px 10px);
+  opacity: 0.4;
+}
+
+.chrome .logo {
+  font-family: var(--t-display);
+  font-style: var(--t-display-style);
+  font-weight: var(--t-display-weight);
+  font-size: 26px;
+  letter-spacing: -0.01em;
+  text-transform: none;
+  color: var(--t-ink);
+  position: relative;
+  padding-right: 4px;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+.chrome .logo-dot {
+  display: inline-block;
+  width: 7px; height: 7px; border-radius: 50%;
+  background: var(--t-seal);
+  margin-left: 2px;
+  margin-bottom: 4px;
+  vertical-align: middle;
+  box-shadow: 0 1px 0 rgba(0,0,0,0.25), inset 0 1px 1px rgba(255,255,255,0.3);
+}
+.chrome .crumbs { display: flex; gap: 16px; align-items: center; }
+.chrome .crumb { transition: color 200ms; }
+.chrome .crumb.now { color: var(--t-ink); position: relative; }
+.chrome .crumb.now::after {
+  content: ''; position: absolute; left: 0; right: 0; bottom: -4px;
+  height: 1px; background: var(--t-seal);
+}
+.chrome .right { display: flex; gap: 18px; align-items: center; }
+
+/* byline = wax seal pip + label */
+.byline {
+  display: flex; align-items: center; gap: 8px;
+  font-family: var(--t-mono);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--t-ink-soft);
+}
+.byline-dot {
+  width: 10px; height: 10px; border-radius: 50%;
+  background: radial-gradient(circle at 35% 30%,
+    color-mix(in srgb, var(--t-seal) 80%, white) 0%,
+    var(--t-seal) 50%,
+    var(--t-accent-deep) 100%);
+  box-shadow:
+    0 1px 1px rgba(0,0,0,0.3),
+    inset 0 1px 1px rgba(255,255,255,0.35),
+    inset 0 -1px 1px rgba(0,0,0,0.25);
+  position: relative;
+}
+.byline-dot::after {
+  content: ''; position: absolute; inset: 2px;
+  border-radius: 50%;
+  border: 0.5px solid color-mix(in srgb, var(--t-seal) 50%, black);
+  opacity: 0.4;
+}
+
+/* ───────────────────────────────────────────────
+   stage
+   ─────────────────────────────────────────────── */
+
+.stage {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 56px 32px 96px;
+  position: relative;
+}
+
+/* ───────────────────────────────────────────────
+   typography
+   ─────────────────────────────────────────────── */
+
+.eyebrow {
+  font-family: var(--t-mono);
+  font-size: 10px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--t-ink-faint);
+  font-weight: 500;
+}
+.eyebrow.accent { color: var(--t-accent); }
+
+.h-display {
+  font-family: var(--t-display);
+  font-style: var(--t-display-style);
+  font-weight: var(--t-display-weight);
+  line-height: 1.05;
+  letter-spacing: -0.018em;
+  font-size: 76px;
+  color: var(--t-ink);
+  margin: 0;
+  text-wrap: pretty;
+}
+.h-display.smaller { font-size: 52px; line-height: 1.08; }
+.h-display.tiny { font-size: 36px; line-height: 1.1; }
+
+.body-prose {
+  font-family: var(--t-body);
+  font-size: 19px;
+  line-height: 1.6;
+  color: var(--t-ink-soft);
+  text-wrap: pretty;
+}
+
+.serif-italic {
+  font-family: var(--t-display);
+  font-style: italic;
+  font-weight: var(--t-display-weight);
+}
+
+.muted { color: var(--t-ink-faint); }
+
+/* drop cap */
+.drop-cap::first-letter {
+  font-family: var(--t-display);
+  font-style: var(--t-display-style);
+  font-weight: 700;
+  font-size: 4.4em;
+  float: left;
+  line-height: 0.82;
+  margin: 0.06em 0.08em 0 -0.04em;
+  color: var(--t-accent);
+}
+
+/* ───────────────────────────────────────────────
+   buttons — stamped impressions
+   ─────────────────────────────────────────────── */
+
+.btn {
+  display: inline-flex; align-items: center; gap: 10px;
+  padding: 12px 22px;
+  border: 1.5px solid var(--t-ink);
+  border-radius: var(--t-radius);
+  background: transparent;
+  font-family: var(--t-mono);
+  font-weight: 500;
+  font-size: 12px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--t-ink);
+  cursor: pointer;
+  transition: background 200ms, color 200ms, transform 80ms, box-shadow 200ms;
+  position: relative;
+}
+.btn:hover { background: var(--t-ink); color: var(--t-paper); }
+.btn:active { transform: translateY(1px); }
+
+.btn.primary {
+  background: var(--t-accent);
+  border-color: var(--t-accent);
+  color: var(--t-paper);
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, var(--t-accent) 60%, white),
+    inset 0 -1px 1px var(--t-accent-deep),
+    0 1px 0 var(--t-accent-deep);
+}
+.btn.primary:hover {
+  background: var(--t-accent-deep);
+  border-color: var(--t-accent-deep);
+}
+
+.btn.ghost {
+  border-style: dashed;
+  border-color: var(--t-ink-faint);
+  color: var(--t-ink-soft);
+}
+.btn.sm { padding: 8px 14px; font-size: 10px; letter-spacing: 0.16em; }
+
+/* stamped — looks like an ink stamp on paper */
+.btn.stamp {
+  font-family: var(--t-stamp);
+  font-size: 14px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  border: 2.5px solid var(--t-accent);
+  color: var(--t-accent);
+  background: transparent;
+  padding: 8px 18px;
+  transform: rotate(-1.5deg);
+  border-radius: 1px;
+  position: relative;
+}
+.btn.stamp::after {
+  content: ''; position: absolute; inset: -3px;
+  border: 2.5px solid transparent;
+  pointer-events: none;
+}
+.btn.stamp:hover { background: var(--t-accent-soft); transform: rotate(-1.5deg) translateY(-1px); }
+
+/* ───────────────────────────────────────────────
+   plates / cards — debossed paper
+   ─────────────────────────────────────────────── */
+
+.card {
+  background: var(--t-paper);
+  border: 1px solid var(--t-ink-ghost);
+  border-radius: var(--t-radius);
+  padding: 20px 22px;
+  transition: background 800ms, border-color 800ms, transform 200ms, box-shadow 200ms;
+  position: relative;
+}
+
+/* debossed plate — content "pressed in" */
+.plate {
+  background: var(--t-paper);
+  border: 1px solid var(--t-ink-ghost);
+  border-radius: var(--t-radius);
+  padding: 24px 26px;
+  position: relative;
+  box-shadow:
+    inset 0 1px 0 var(--t-paper-highlight),
+    inset 0 -1px 0 var(--t-paper-shadow),
+    0 0 0 1px color-mix(in srgb, var(--t-ink) 6%, transparent);
+}
+.plate.deep {
+  background: linear-gradient(180deg,
+    color-mix(in srgb, var(--t-paper) 96%, var(--t-paper-shadow)) 0%,
+    var(--t-paper) 50%,
+    var(--t-paper-warm) 100%);
+  box-shadow:
+    inset 0 2px 4px var(--t-paper-shadow),
+    inset 0 1px 0 var(--t-paper-highlight),
+    0 0 0 1px var(--t-ink-ghost);
+}
+
+/* embossed plate — content raised */
+.plate.raised {
+  background: var(--t-paper);
+  box-shadow:
+    inset 0 1px 0 var(--t-paper-highlight),
+    inset 0 -2px 3px var(--t-paper-shadow),
+    0 1px 0 var(--t-paper-highlight),
+    0 4px 12px var(--t-paper-shadow);
+}
+
+.card.outlined { border-color: var(--t-ink-soft); }
+.card.selected {
+  border-color: var(--t-accent);
+  box-shadow:
+    0 0 0 1px var(--t-accent),
+    0 8px 28px var(--t-accent-soft),
+    inset 0 1px 0 var(--t-paper-highlight);
+}
+.card.bare {
+  background: transparent;
+  border-style: dashed;
+  border-color: var(--t-ink-faint);
+}
+
+/* deckle edge — torn/uneven paper */
+.deckle {
+  position: relative;
+  background: var(--t-paper);
+  --deckle-mask: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='200' height='10' preserveAspectRatio='none'><path d='M 0 10 L 0 7 Q 8 4, 16 6 T 32 5 T 48 7 T 64 4 T 80 6 T 96 5 T 112 7 T 128 5 T 144 6 T 160 4 T 176 7 T 192 5 T 200 6 L 200 10 Z' fill='black'/></svg>");
+}
+.deckle::before, .deckle::after {
+  content: ''; position: absolute; left: 0; right: 0; height: 10px;
+  background: var(--t-paper);
+  -webkit-mask: var(--deckle-mask) repeat-x;
+          mask: var(--deckle-mask) repeat-x;
+}
+.deckle::before { top: -8px; transform: scaleY(-1); }
+.deckle::after  { bottom: -8px; }
+
+/* ───────────────────────────────────────────────
+   tags
+   ─────────────────────────────────────────────── */
+
+.tag {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 4px 10px;
+  font-family: var(--t-mono);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--t-ink-soft);
+  background: transparent;
+  border: 1px solid var(--t-ink-ghost);
+  border-radius: 999px;
+  cursor: pointer;
+  transition: all 200ms;
+}
+.tag:hover { border-color: var(--t-ink); }
+.tag.on {
+  background: var(--t-accent); color: var(--t-paper); border-color: var(--t-accent);
+  box-shadow: inset 0 1px 0 color-mix(in srgb, var(--t-accent) 60%, white);
+}
+
+/* ───────────────────────────────────────────────
+   inputs
+   ─────────────────────────────────────────────── */
+
+.input-stroke {
+  border: none;
+  border-bottom: 1.5px solid var(--t-ink);
+  background: transparent;
+  font-family: var(--t-display);
+  font-style: var(--t-display-style);
+  font-size: 28px;
+  color: var(--t-ink);
+  padding: 8px 2px;
+  width: 100%;
+  outline: none;
+}
+.input-stroke::placeholder { color: var(--t-ink-faint); }
+
+.textarea-prose {
+  width: 100%;
+  border: 1px solid var(--t-ink-ghost);
+  border-radius: var(--t-radius);
+  background: var(--t-paper);
+  padding: 18px 22px;
+  font-family: var(--t-body);
+  font-size: 18px;
+  line-height: 1.65;
+  color: var(--t-ink);
+  resize: none;
+  outline: none;
+  transition: border-color 200ms, background 800ms, box-shadow 200ms;
+  box-shadow: inset 0 1px 0 var(--t-paper-highlight), inset 0 -1px 0 var(--t-paper-shadow);
+}
+.textarea-prose:focus {
+  border-color: var(--t-accent);
+  box-shadow:
+    inset 0 1px 0 var(--t-paper-highlight),
+    inset 0 -1px 0 var(--t-paper-shadow),
+    0 0 0 3px var(--t-accent-soft);
+}
+
+/* ruled paper variant — for the artifact */
+.textarea-prose.ruled {
+  background:
+    repeating-linear-gradient(transparent 0 calc(1.65em - 1px),
+      var(--t-ink-ghost) calc(1.65em - 1px) 1.65em),
+    var(--t-paper);
+  background-attachment: local;
+  line-height: 1.65em;
+  padding-top: calc(18px + 2px);
+}
+
+/* ───────────────────────────────────────────────
+   ornaments / dividers
+   ─────────────────────────────────────────────── */
+
+.ornament { display: block; height: 16px; color: var(--t-ornament-color); }
+
+.divider-flourish {
+  display: flex; align-items: center; gap: 18px; margin: 28px 0;
+  color: var(--t-ornament-color);
+}
+.divider-flourish::before, .divider-flourish::after {
+  content: ''; flex: 1; height: 1px;
+  background:
+    repeating-linear-gradient(90deg, currentColor 0 4px, transparent 4px 7px);
+  opacity: 0.7;
+}
+.divider-flourish .ornament-glyph {
+  font-family: var(--t-display);
+  font-style: italic;
+  font-size: 16px;
+  color: var(--t-seal);
+  letter-spacing: 0.4em;
+  opacity: 0.85;
+}
+
+/* progress dots */
+.progress-dots { display: flex; gap: 6px; align-items: center; }
+.progress-dots .d {
+  width: 7px; height: 7px; border-radius: 50%;
+  background: var(--t-ink-ghost);
+  transition: background 200ms, transform 200ms;
+}
+.progress-dots .d.on {
+  background: var(--t-accent);
+  box-shadow: 0 0 0 3px var(--t-accent-soft);
+}
+
+/* ───────────────────────────────────────────────
+   theme slider — brass dial in chrome
+   ─────────────────────────────────────────────── */
+
+.theme-slider {
+  display: flex; align-items: center; gap: 10px;
+  padding: 6px 12px;
+  border: 1px solid var(--t-ink-ghost);
+  border-radius: 999px;
+  background: var(--t-paper);
+  box-shadow: inset 0 1px 0 var(--t-paper-highlight), inset 0 -1px 0 var(--t-paper-shadow);
+}
+.theme-slider .label {
+  font-family: var(--t-mono); font-size: 9px; letter-spacing: 0.18em;
+  color: var(--t-ink-faint); text-transform: uppercase;
+}
+.theme-slider .track {
+  position: relative; width: 168px; height: 18px;
+  display: flex; align-items: center;
+}
+.theme-slider .track::before {
+  content: ''; position: absolute; left: 6px; right: 6px; height: 2px;
+  background: linear-gradient(90deg, #d34860, #8b2418, #4a6b3a, #d4a85a, #b89be0);
+  border-radius: 2px;
+  opacity: 0.85;
+}
+.theme-slider .pip {
+  flex: 1; display: flex; justify-content: center; position: relative; z-index: 1;
+  cursor: pointer; background: none; border: none; padding: 0;
+}
+.theme-slider .pip span {
+  width: 10px; height: 10px; border-radius: 50%;
+  background: var(--t-paper);
+  border: 1.5px solid var(--t-ink-faint);
+  transition: all 200ms;
+}
+.theme-slider .pip:hover span { transform: scale(1.2); border-color: var(--t-ink); }
+.theme-slider .pip.on span {
+  background: var(--t-accent); border-color: var(--t-accent);
+  transform: scale(1.4);
+  box-shadow: 0 0 0 3px var(--t-accent-soft), inset 0 1px 0 rgba(255,255,255,0.35);
+}
+
+/* ───────────────────────────────────────────────
+   highlight + verbatim mark
+   ─────────────────────────────────────────────── */
+
+.hl {
+  background: linear-gradient(transparent 60%, var(--t-highlight) 60% 90%, transparent 90%);
+  padding: 0 2px;
+}
+
+/* hover trace popover */
+.trace-line {
+  position: relative; cursor: help;
+  transition: background 200ms;
+  padding: 0 2px; margin: 0 -2px;
+  border-radius: 1px;
+}
+.trace-line:hover { background: var(--t-accent-soft); }
+.trace-line::after {
+  content: ''; position: absolute; left: 2px; right: 2px; bottom: -1px;
+  height: 1px;
+  background: var(--t-verified);
+  opacity: 0.22;
+}
+
+.trace-pop {
+  position: fixed; z-index: 80; width: 340px;
+  background: var(--t-paper);
+  border: 1px solid var(--t-ink);
+  border-radius: var(--t-radius);
+  padding: 16px 18px;
+  font-family: var(--t-body);
+  font-size: 13px; line-height: 1.55;
+  color: var(--t-ink-soft);
+  box-shadow:
+    0 1px 0 var(--t-paper-highlight),
+    0 14px 44px rgba(0,0,0,0.20),
+    inset 0 1px 0 var(--t-paper-highlight);
+  pointer-events: none;
+}
+
+/* ───────────────────────────────────────────────
+   postal motifs
+   ─────────────────────────────────────────────── */
+
+/* postage-stamp frame */
+.postage {
+  position: relative;
+  background: var(--t-paper);
+  padding: 14px 16px;
+  --stamp-mask: radial-gradient(circle at 4px 4px, transparent 3px, black 3.5px);
+  --stamp-mask-size: 8px 8px;
+  border-radius: 0;
+  box-shadow:
+    inset 0 1px 0 var(--t-paper-highlight),
+    0 2px 6px var(--t-paper-shadow);
+}
+.postage::before {
+  content: ''; position: absolute; inset: -4px;
+  background: var(--t-paper);
+  -webkit-mask:
+    radial-gradient(circle at 0 0, transparent 4px, black 4.5px) 0 0 / 8px 8px,
+    radial-gradient(circle at 100% 0, transparent 4px, black 4.5px) 0 0 / 8px 8px;
+  z-index: -1;
+}
+/* simpler: use perforated edge via repeating mask */
+.postage-edge {
+  --d: 6px;
+  -webkit-mask:
+    radial-gradient(circle at var(--d) var(--d), transparent calc(var(--d) - 1.5px), black calc(var(--d) - 1px)) 0 0 / calc(var(--d) * 2) calc(var(--d) * 2);
+          mask:
+    radial-gradient(circle at var(--d) var(--d), transparent calc(var(--d) - 1.5px), black calc(var(--d) - 1px)) 0 0 / calc(var(--d) * 2) calc(var(--d) * 2);
+}
+
+/* postmark — circular ink stamp, slightly tilted */
+.postmark {
+  display: inline-flex; flex-direction: column; align-items: center; justify-content: center;
+  width: 110px; height: 110px;
+  border: 2.5px solid var(--t-accent);
+  border-radius: 50%;
+  color: var(--t-accent);
+  font-family: var(--t-stamp);
+  text-transform: uppercase;
+  text-align: center;
+  letter-spacing: 0.06em;
+  padding: 8px;
+  transform: rotate(-6deg);
+  position: relative;
+  background: transparent;
+  opacity: 0.92;
+}
+.postmark::before, .postmark::after {
+  content: ''; position: absolute; left: 6px; right: 6px;
+  height: 1.5px; background: var(--t-accent);
+}
+.postmark::before { top: 24px; }
+.postmark::after { bottom: 24px; }
+.postmark .pm-top { font-size: 9px; letter-spacing: 0.16em; }
+.postmark .pm-mid { font-size: 16px; font-weight: 700; line-height: 1; margin: 4px 0; }
+.postmark .pm-bot { font-size: 9px; letter-spacing: 0.16em; }
+
+/* wax seal */
+.seal {
+  position: relative;
+  width: 64px; height: 64px;
+  border-radius: 50%;
+  background:
+    radial-gradient(circle at 30% 28%,
+      color-mix(in srgb, var(--t-seal) 70%, white) 0%,
+      var(--t-seal) 35%,
+      var(--t-accent-deep) 90%);
+  display: flex; align-items: center; justify-content: center;
+  box-shadow:
+    0 1px 1px rgba(0,0,0,0.3),
+    0 4px 10px rgba(0,0,0,0.18),
+    inset 0 2px 3px rgba(255,255,255,0.32),
+    inset 0 -3px 4px rgba(0,0,0,0.32);
+}
+.seal::before {
+  content: ''; position: absolute; inset: -4px -4px -4px -4px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 50% 50%, transparent 60%, var(--t-seal) 62%, transparent 75%);
+  filter: blur(0.6px);
+  opacity: 0.55;
+  z-index: -1;
+  /* drips */
+  clip-path: polygon(
+    0% 50%, 8% 30%, 18% 40%, 30% 18%, 42% 32%, 50% 12%,
+    60% 28%, 72% 18%, 82% 36%, 92% 26%, 100% 50%,
+    96% 70%, 88% 88%, 76% 76%, 60% 92%, 50% 80%, 38% 96%, 24% 78%, 12% 90%, 4% 70%
+  );
+}
+.seal-glyph {
+  font-family: var(--t-display);
+  font-style: italic;
+  font-weight: 700;
+  font-size: 24px;
+  color: color-mix(in srgb, var(--t-seal) 30%, black);
+  text-shadow: 0 1px 0 rgba(255,255,255,0.18);
+  user-select: none;
+}
+
+/* corner postmark — small, top-right of artifact */
+.corner-stamp {
+  position: absolute; top: 18px; right: 18px;
+  transform: rotate(8deg);
+}
+
+/* ───────────────────────────────────────────────
+   tape / scotch
+   ─────────────────────────────────────────────── */
+
+.tape {
+  position: absolute;
+  background: var(--t-tape);
+  height: 24px; width: 80px;
+  opacity: 0.7;
+  box-shadow: inset 0 1px 1px rgba(255,255,255,0.35), inset 0 -1px 1px rgba(0,0,0,0.18);
+  border-left: 1px dashed rgba(0,0,0,0.18);
+  border-right: 1px dashed rgba(0,0,0,0.18);
+  pointer-events: none;
+}
+.tape.tl { top: -10px; left: 24px; transform: rotate(-3deg); }
+.tape.tr { top: -10px; right: 24px; transform: rotate(2deg); }
+
+/* ───────────────────────────────────────────────
+   ambient motion (per theme)
+   ─────────────────────────────────────────────── */
+
+@keyframes float-y { 0%, 100% { transform: translateY(0); } 50% { transform: translateY(-6px); } }
+@keyframes pulse-fade { 0%, 100% { opacity: 0.85; } 50% { opacity: 1; } }
+@keyframes sway { 0%, 100% { transform: rotate(-1deg); } 50% { transform: rotate(1deg); } }
+
+.theme-cute   .anim-mascot { animation: float-y 4s ease-in-out infinite, sway 6s ease-in-out infinite; transform-origin: center bottom; }
+.theme-warm   .anim-mascot { animation: float-y 6s ease-in-out infinite; }
+.theme-quiet  .anim-mascot { animation: float-y 9s ease-in-out infinite; }
+.theme-noir   .anim-mascot { animation: pulse-fade 5s ease-in-out infinite; }
+.theme-gothic .anim-mascot { animation: pulse-fade 7s ease-in-out infinite; }
+
+/* ───────────────────────────────────────────────
+   utilities
+   ─────────────────────────────────────────────── */
+
+.no-scrollbar::-webkit-scrollbar { display: none; }
+.no-scrollbar { scrollbar-width: none; }
+
+/* keep transitions calm but coordinated */
+.app, .chrome, .card, .plate, .btn, .tag, .textarea-prose {
+  transition-property: background, color, border-color, box-shadow;
+  transition-duration: 800ms;
+}
+
+/* ───────────────────────────────────────────────
+   modal / overlay (used by download/save/share)
+   ─────────────────────────────────────────────── */
+
+.scrim {
+  position: fixed; inset: 0; z-index: 200;
+  background:
+    radial-gradient(ellipse at center, color-mix(in srgb, var(--t-ink) 25%, transparent) 0%, color-mix(in srgb, var(--t-ink) 70%, transparent) 100%);
+  backdrop-filter: blur(6px);
+  display: flex; align-items: center; justify-content: center;
+  animation: fadein 240ms ease;
+  padding: 24px;
+  overflow-y: auto;
+}
+@keyframes fadein { from { opacity: 0; transform: translateY(4px); } to { opacity: 1; transform: none; } }
+@keyframes blink { 50% { opacity: 0; } }
+@keyframes stamp-in { 0% { transform: scale(1.6) rotate(-12deg); opacity: 0; } 100% { transform: scale(1) rotate(-6deg); opacity: 0.92; } }
+
+.dialog {
+  background: var(--t-paper);
+  border: 1px solid var(--t-ink);
+  border-radius: var(--t-radius);
+  padding: 36px 40px;
+  max-width: 560px;
+  width: 100%;
+  position: relative;
+  box-shadow:
+    0 1px 0 var(--t-paper-highlight),
+    0 24px 80px rgba(0,0,0,0.32),
+    inset 0 1px 0 var(--t-paper-highlight);
+  max-height: calc(100vh - 48px);
+  overflow-y: auto;
+}
+.dialog .close {
+  position: absolute; top: 14px; right: 14px;
+  background: none; border: none; cursor: pointer;
+  font-family: var(--t-mono); font-size: 11px; color: var(--t-ink-faint);
+  letter-spacing: 0.14em; text-transform: uppercase;
+  padding: 4px 8px;
+}
+.dialog .close:hover { color: var(--t-ink); }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,13 @@
 import type { Metadata } from "next";
+import { Playfair_Display, EB_Garamond, JetBrains_Mono, Special_Elite, Caveat, Fraunces } from "next/font/google";
 import "./globals.css";
+
+const playfair = Playfair_Display({ subsets: ["latin"], variable: "--font-playfair-display", display: "swap" });
+const garamond = EB_Garamond({ subsets: ["latin"], variable: "--font-eb-garamond", display: "swap" });
+const jetbrains = JetBrains_Mono({ subsets: ["latin"], variable: "--font-jetbrains-mono", display: "swap" });
+const specialElite = Special_Elite({ weight: "400", subsets: ["latin"], variable: "--font-special-elite", display: "swap" });
+const caveat = Caveat({ subsets: ["latin"], variable: "--font-caveat", display: "swap" });
+const fraunces = Fraunces({ subsets: ["latin"], variable: "--font-fraunces", display: "swap" });
 
 export const metadata: Metadata = {
   title: "Mean It",
@@ -12,8 +20,8 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en" className="theme-edge">
-      <body className="min-h-screen transition-theme">{children}</body>
+    <html lang="en" className={`theme-quiet ${playfair.variable} ${garamond.variable} ${jetbrains.variable} ${specialElite.variable} ${caveat.variable} ${fraunces.variable}`}>
+      <body className="min-h-screen">{children}</body>
     </html>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,16 @@
-import { EntryScreen } from "@/components/EntryScreen";
-import { GUIDE_STUBS } from "@/lib/guides";
+import { loadBuiltInGuides } from "@/lib/guides/loader";
+import { App } from "@/components/App";
+import path from "node:path";
+import type { Guide } from "@/lib/guides/schema";
 
 export default function Page() {
-  return <EntryScreen guides={GUIDE_STUBS} />;
+  const guidesPath = path.join(process.cwd(), "prompts", "guides");
+  let guides: Guide[] = [];
+  try {
+    guides = loadBuiltInGuides(guidesPath);
+  } catch(e) {
+    console.error("Failed to load guides:", e);
+  }
+
+  return <App guides={guides} />;
 }

--- a/components/App.tsx
+++ b/components/App.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { useAppStore } from "@/lib/store";
+import { Chrome } from "./Chrome";
+import { PickMoment } from "./screens/PickMoment";
+import { GuidePicker } from "./screens/GuidePicker";
+import { Spine } from "./screens/Spine";
+import { Render } from "./screens/Render";
+import type { Guide } from "@/lib/guides/schema";
+
+export function App({ guides }: { guides: Guide[] }) {
+  const [{ step }] = useAppStore();
+
+  return (
+    <div className="app">
+      <div className="grain" />
+      <Chrome />
+      <main>
+        {step === "moment" && <PickMoment />}
+        {step === "guide" && <GuidePicker guides={guides} />}
+        {step === "interview" && <div className="stage text-center">Interview screen coming soon...</div>}
+        {step === "spine" && <Spine />}
+        {step === "drafting" && <div className="stage text-center">Drafting screen coming soon...</div>}
+        {step === "render" && <Render />}
+      </main>
+    </div>
+  );
+}

--- a/components/Chrome.tsx
+++ b/components/Chrome.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { useAppStore } from "@/lib/store";
+import { ThemeSlider } from "./ThemeSlider";
+
+export function Chrome() {
+  const [{ step }] = useAppStore();
+
+  return (
+    <header className="chrome">
+      <div className="left flex items-center gap-4">
+        <div className="logo">
+          Mean It<span className="logo-dot" />
+        </div>
+        <div className="crumbs">
+          <span className={`crumb ${step === "moment" ? "now" : "muted"}`}>Start</span>
+          <span className="muted">/</span>
+          <span className={`crumb ${step === "guide" ? "now" : "muted"}`}>Guide</span>
+          <span className="muted">/</span>
+          <span className={`crumb ${["interview", "spine", "drafting", "render"].includes(step) ? "now" : "muted"}`}>Draft</span>
+        </div>
+      </div>
+      
+      <div className="right">
+        <ThemeSlider />
+        <div className="byline">
+          <span className="byline-dot" />
+          By Claude
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/components/ThemeSlider.tsx
+++ b/components/ThemeSlider.tsx
@@ -1,141 +1,33 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { applyTheme } from "@/lib/theme";
-import { saveSession } from "@/lib/session";
+import { useEffect } from "react";
+import { useAppStore, actions } from "@/lib/store";
+import type { Theme } from "@/lib/types/session";
 
-interface Props {
-  vibe: number; // 0=Soft/Cute, 100=Bold/Gothic
-  onChange: (vibe: number) => void;
-}
+const THEMES: Theme[] = ["cute", "warm", "quiet", "noir", "gothic"];
 
-export function ThemeSlider({ vibe, onChange }: Props) {
-  const [isDragging, setIsDragging] = useState(false);
+export function ThemeSlider() {
+  const [{ theme }, dispatch] = useAppStore();
 
+  // Sync the theme to the <html> class on mount and when it changes.
   useEffect(() => {
-    applyTheme(vibe, 30);
-  }, [vibe]);
-
-  function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
-    const next = Number(e.target.value);
-    onChange(next);
-    saveSession({ vibe: next });
-  }
-
-  const accentColor = vibe < 50 ? "#FF69B4" : "#8B5CF6";
+    document.documentElement.className = `theme-${theme}`;
+  }, [theme]);
 
   return (
-    <div className="fixed bottom-8 left-1/2 -translate-x-1/2 z-50 w-full max-w-md px-6">
-      <div
-        className="backdrop-blur-md rounded-3xl p-6 shadow-2xl transition-all duration-500"
-        style={{
-          backgroundColor:
-            vibe < 50
-              ? "rgba(255, 245, 250, 0.95)"
-              : `rgba(30, 20, 40, ${0.85 + (vibe - 50) / 200})`,
-          border: `2px solid ${vibe < 50 ? "rgba(255, 182, 193, 0.5)" : "rgba(139, 92, 246, 0.5)"}`,
-        }}
-      >
-        <div className="flex items-center justify-between mb-4">
-          <div className="flex items-center gap-2">
-            <span
-              className="transition-all duration-500"
-              style={{
-                fontSize: "20px",
-                opacity: 1 - vibe / 100,
-              }}
-            >
-              ✨
-            </span>
-            <span
-              className="transition-all duration-500"
-              style={{
-                fontFamily: "var(--font-sans)",
-                fontSize: "14px",
-                color: vibe < 50 ? "#FF69B4" : "#8B5CF6",
-                fontWeight: 500,
-              }}
-            >
-              Soft & Cute
-            </span>
-          </div>
-          <div className="flex items-center gap-2">
-            <span
-              className="transition-all duration-500"
-              style={{
-                fontFamily: "var(--font-sans)",
-                fontSize: "14px",
-                color: vibe >= 50 ? "#8B5CF6" : "#D3D1C7",
-                fontWeight: 500,
-              }}
-            >
-              Bold & Gothic
-            </span>
-            <span
-              className="transition-all duration-500"
-              style={{
-                fontSize: "20px",
-                opacity: vibe / 100,
-              }}
-            >
-              🌙
-            </span>
-          </div>
-        </div>
-
-        {/* Custom slider track */}
-        <div className="relative h-2 mb-4">
-          <div
-            className="absolute inset-0 rounded-full transition-all duration-500"
-            style={{
-              background:
-                vibe < 50
-                  ? "linear-gradient(to right, #FFB6C1, #FFC0CB, #DDA0DD)"
-                  : "linear-gradient(to right, #6B46C1, #8B5CF6, #4C1D95)",
-            }}
-          />
-          <input
-            type="range"
-            min="0"
-            max="100"
-            value={vibe}
-            onChange={handleChange}
-            onMouseDown={() => setIsDragging(true)}
-            onMouseUp={() => setIsDragging(false)}
-            onTouchStart={() => setIsDragging(true)}
-            onTouchEnd={() => setIsDragging(false)}
-            aria-label="Your vibe: Soft/Cute to Bold/Gothic"
-            className="absolute inset-0 w-full opacity-0 cursor-pointer z-10"
-          />
-          <div
-            className="absolute top-1/2 -translate-y-1/2 w-6 h-6 rounded-full shadow-lg transition-all duration-200"
-            style={{
-              left: `calc(${vibe}% - 12px)`,
-              backgroundColor: accentColor,
-              transform: `translateY(-50%) scale(${isDragging ? 1.2 : 1})`,
-              boxShadow: `0 0 ${isDragging ? "20px" : "10px"} ${
-                vibe < 50
-                  ? "rgba(255, 105, 180, 0.5)"
-                  : "rgba(139, 92, 246, 0.5)"
-              }`,
-            }}
-          />
-        </div>
-
-        {/* Mood label */}
-        <div
-          className="text-center transition-all duration-500"
-          style={{
-            fontFamily: "var(--font-serif)",
-            fontSize: "12px",
-            color: accentColor,
-          }}
-        >
-          {vibe < 25 && "✨ Whimsical & Dreamy"}
-          {vibe >= 25 && vibe < 50 && "🌸 Sweet & Enchanting"}
-          {vibe >= 50 && vibe < 75 && "🌙 Mysterious & Elegant"}
-          {vibe >= 75 && "🦇 Dark & Dramatic"}
-        </div>
+    <div className="theme-slider">
+      <div className="label">Vibe</div>
+      <div className="track">
+        {THEMES.map((t) => (
+          <button
+            key={t}
+            className={`pip ${theme === t ? "on" : ""}`}
+            onClick={() => dispatch(actions.setTheme(t))}
+            aria-label={`Switch to ${t} theme`}
+          >
+            <span />
+          </button>
+        ))}
       </div>
     </div>
   );

--- a/components/mascots/Cassio.tsx
+++ b/components/mascots/Cassio.tsx
@@ -1,0 +1,35 @@
+import { Eyes } from "./Eyes";
+import { Mouth } from "./Mouth";
+import { ink } from "./_shared";
+import type { Emotion } from "./types";
+
+interface CassioProps {
+  emotion?: Emotion;
+  size?: number;
+}
+
+// Songwriter's mascot — long-form crescent.
+export function Cassio({ emotion = "moved", size = 96 }: CassioProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 68 68"
+      className="anim-mascot"
+      role="img"
+      aria-label={`Cassio mascot, ${emotion}`}
+    >
+      <path
+        d="M 50 14 q -28 4 -28 22 q 0 18 28 22 q -16 -8 -16 -22 q 0 -14 16 -22 z"
+        {...ink({ strokeWidth: 1.6 })}
+      />
+      <path
+        d="M 16 56 q 4 -3 8 0 t 8 0"
+        {...ink({ strokeWidth: 0.9 })}
+        opacity={0.5}
+      />
+      <Eyes emotion={emotion} x1={30} x2={42} y={32} />
+      <Mouth emotion={emotion} cx={36} cy={42} />
+    </svg>
+  );
+}

--- a/components/mascots/Eyes.tsx
+++ b/components/mascots/Eyes.tsx
@@ -1,0 +1,66 @@
+import { ACCENT, STROKE, ink } from "./_shared";
+import type { Emotion } from "./types";
+
+interface EyesProps {
+  emotion: Emotion;
+  x1?: number;
+  x2?: number;
+  y?: number;
+}
+
+export function Eyes({ emotion, x1 = 26, x2 = 42, y = 30 }: EyesProps) {
+  if (emotion === "listening") {
+    return (
+      <g>
+        <circle cx={x1} cy={y} r={1.4} fill={STROKE} />
+        <circle cx={x2} cy={y} r={1.4} fill={STROKE} />
+      </g>
+    );
+  }
+  if (emotion === "curious") {
+    return (
+      <g>
+        <path d={`M ${x1 - 3} ${y - 3} q 3 -2 6 0`} {...ink()} />
+        <circle cx={x1} cy={y} r={1.4} fill={STROKE} />
+        <circle cx={x2} cy={y} r={1.4} fill={STROKE} />
+      </g>
+    );
+  }
+  if (emotion === "moved") {
+    return (
+      <g>
+        <path d={`M ${x1 - 3} ${y} q 3 2 6 0`} {...ink()} />
+        <path d={`M ${x2 - 3} ${y} q 3 2 6 0`} {...ink()} />
+      </g>
+    );
+  }
+  if (emotion === "sad") {
+    return (
+      <g>
+        <path d={`M ${x1 - 3} ${y + 2} q 3 -3 6 0`} {...ink()} />
+        <path d={`M ${x2 - 3} ${y + 2} q 3 -3 6 0`} {...ink()} />
+        <path
+          d={`M ${x2 + 1} ${y + 4} q 1 4 0 6`}
+          {...ink({ stroke: ACCENT, strokeWidth: 1 })}
+        />
+      </g>
+    );
+  }
+  if (emotion === "hopeful") {
+    return (
+      <g>
+        <circle cx={x1 + 1} cy={y - 1.5} r={1.4} fill={STROKE} />
+        <circle cx={x2 + 1} cy={y - 1.5} r={1.4} fill={STROKE} />
+      </g>
+    );
+  }
+  if (emotion === "silence") {
+    return (
+      <g>
+        <path d={`M ${x1 - 3} ${y} h 6`} {...ink()} />
+        <path d={`M ${x2 - 3} ${y} h 6`} {...ink()} />
+      </g>
+    );
+  }
+  return null;
+}

--- a/components/mascots/Mascot.tsx
+++ b/components/mascots/Mascot.tsx
@@ -1,0 +1,17 @@
+import { Cassio } from "./Cassio";
+import { Pip } from "./Pip";
+import { Wren } from "./Wren";
+import type { Emotion, MascotId } from "./types";
+
+interface MascotProps {
+  id: MascotId;
+  emotion?: Emotion;
+  size?: number;
+}
+
+export function Mascot({ id, emotion, size }: MascotProps) {
+  if (id === "wren") return <Wren emotion={emotion} size={size} />;
+  if (id === "pip") return <Pip emotion={emotion} size={size} />;
+  if (id === "cassio") return <Cassio emotion={emotion} size={size} />;
+  return null;
+}

--- a/components/mascots/Mouth.tsx
+++ b/components/mascots/Mouth.tsx
@@ -1,0 +1,30 @@
+import { ink } from "./_shared";
+import type { Emotion } from "./types";
+
+interface MouthProps {
+  emotion: Emotion;
+  cx?: number;
+  cy?: number;
+}
+
+export function Mouth({ emotion, cx = 34, cy = 40 }: MouthProps) {
+  if (emotion === "listening") {
+    return <path d={`M ${cx - 3} ${cy} h 6`} {...ink()} />;
+  }
+  if (emotion === "curious") {
+    return <path d={`M ${cx - 3} ${cy - 1} q 3 3 6 0`} {...ink()} />;
+  }
+  if (emotion === "moved") {
+    return <path d={`M ${cx - 3} ${cy - 1} q 3 2 6 -1`} {...ink()} />;
+  }
+  if (emotion === "sad") {
+    return <path d={`M ${cx - 4} ${cy + 1} q 4 -3 8 0`} {...ink()} />;
+  }
+  if (emotion === "hopeful") {
+    return <path d={`M ${cx - 3} ${cy - 1} q 3 4 6 0`} {...ink()} />;
+  }
+  if (emotion === "silence") {
+    return <path d={`M ${cx - 2} ${cy} h 4`} {...ink({ strokeWidth: 1.2 })} />;
+  }
+  return null;
+}

--- a/components/mascots/Pip.tsx
+++ b/components/mascots/Pip.tsx
@@ -1,0 +1,41 @@
+import { Eyes } from "./Eyes";
+import { Mouth } from "./Mouth";
+import { ink } from "./_shared";
+import type { Emotion } from "./types";
+
+interface PipProps {
+  emotion?: Emotion;
+  size?: number;
+}
+
+// Poet of Small Things mascot — round petal-bodied creature.
+export function Pip({ emotion = "curious", size = 96 }: PipProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 68 68"
+      className="anim-mascot"
+      role="img"
+      aria-label={`Pip mascot, ${emotion}`}
+    >
+      <path
+        d="M 14 30 q -6 -10 4 -16 q 8 -3 12 6"
+        {...ink({ strokeWidth: 1 })}
+        opacity={0.55}
+      />
+      <path
+        d="M 54 30 q 6 -10 -4 -16 q -8 -3 -12 6"
+        {...ink({ strokeWidth: 1 })}
+        opacity={0.55}
+      />
+      <path
+        d="M 16 36 Q 16 18, 34 16 Q 52 18, 52 36 Q 52 54, 34 56 Q 16 54, 16 36 Z"
+        {...ink({ strokeWidth: 1.6 })}
+      />
+      <path d="M 34 16 q 0 -4 3 -6" {...ink({ strokeWidth: 1 })} />
+      <Eyes emotion={emotion} x1={28} x2={42} y={32} />
+      <Mouth emotion={emotion} cx={34} cy={42} />
+    </svg>
+  );
+}

--- a/components/mascots/Wren.tsx
+++ b/components/mascots/Wren.tsx
@@ -1,0 +1,45 @@
+import { Eyes } from "./Eyes";
+import { Mouth } from "./Mouth";
+import { ink } from "./_shared";
+import type { Emotion } from "./types";
+
+interface WrenProps {
+  emotion?: Emotion;
+  size?: number;
+}
+
+// Documentarian's mascot — feathered creature, single-stroke body.
+export function Wren({ emotion = "listening", size = 96 }: WrenProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 68 68"
+      className="anim-mascot"
+      role="img"
+      aria-label={`Wren mascot, ${emotion}`}
+    >
+      <path
+        d="M 12 50 Q 8 32, 22 18 Q 38 8, 54 22 Q 60 36, 50 50 Q 48 56, 40 56 Q 22 58, 12 50 Z"
+        {...ink({ strokeWidth: 1.6 })}
+      />
+      <path
+        d="M 18 46 Q 26 40, 34 46"
+        {...ink({ strokeWidth: 0.9 })}
+        opacity={0.55}
+      />
+      <path
+        d="M 22 50 Q 30 46, 40 50"
+        {...ink({ strokeWidth: 0.9 })}
+        opacity={0.5}
+      />
+      <path
+        d="M 50 28 l 6 2 l -5 3 z"
+        {...ink({ strokeWidth: 1.2 })}
+        fill="var(--t-paper)"
+      />
+      <Eyes emotion={emotion} x1={28} x2={42} y={28} />
+      <Mouth emotion={emotion} cx={36} cy={38} />
+    </svg>
+  );
+}

--- a/components/mascots/_shared.ts
+++ b/components/mascots/_shared.ts
@@ -1,0 +1,16 @@
+import type { SVGProps } from "react";
+
+// CSS-var refs resolved at render time by `theme.css`.
+export const STROKE = "var(--t-ink)";
+export const ACCENT = "var(--t-accent)";
+
+export const ink = (
+  extra: Partial<SVGProps<SVGPathElement>> = {},
+): SVGProps<SVGPathElement> => ({
+  fill: "none",
+  stroke: STROKE,
+  strokeWidth: 1.4,
+  strokeLinecap: "round",
+  strokeLinejoin: "round",
+  ...extra,
+});

--- a/components/mascots/index.ts
+++ b/components/mascots/index.ts
@@ -1,0 +1,37 @@
+import type { MascotId, MascotMeta } from "./types";
+
+export type { Emotion, MascotId, MascotMeta } from "./types";
+export { EMOTIONS, MASCOT_IDS } from "./types";
+export { Mascot } from "./Mascot";
+export { Wren } from "./Wren";
+export { Pip } from "./Pip";
+export { Cassio } from "./Cassio";
+export { Eyes } from "./Eyes";
+export { Mouth } from "./Mouth";
+
+// Default pairings. Mascots are decoupled — any mascot can run any guide;
+// this is the visual default surfaced in the picker. `guide_id` matches
+// the `id` field in `prompts/guides/*.guide.md`.
+export const MASCOTS: Record<MascotId, MascotMeta> = {
+  wren: {
+    id: "wren",
+    name: "Wren",
+    guide_id: "documentarian",
+    guide_name: "The Documentarian",
+    default_theme: "quiet",
+  },
+  pip: {
+    id: "pip",
+    name: "Pip",
+    guide_id: "poet-of-small-things",
+    guide_name: "The Poet of Small Things",
+    default_theme: "warm",
+  },
+  cassio: {
+    id: "cassio",
+    name: "Cassio",
+    guide_id: "songwriter",
+    guide_name: "The Songwriter",
+    default_theme: "noir",
+  },
+};

--- a/components/mascots/types.ts
+++ b/components/mascots/types.ts
@@ -1,0 +1,30 @@
+export type Emotion =
+  | "listening"
+  | "curious"
+  | "moved"
+  | "sad"
+  | "hopeful"
+  | "silence";
+
+export type MascotId = "wren" | "pip" | "cassio";
+
+export const EMOTIONS: readonly Emotion[] = [
+  "listening",
+  "curious",
+  "moved",
+  "sad",
+  "hopeful",
+  "silence",
+];
+
+export const MASCOT_IDS: readonly MascotId[] = ["wren", "pip", "cassio"];
+
+export interface MascotMeta {
+  id: MascotId;
+  name: string;
+  // Matches Guide.id from `@/lib/guides/schema`. Pairings are presentation —
+  // any mascot can run any guide; this is just the default visual coupling.
+  guide_id: string;
+  guide_name: string;
+  default_theme: "cute" | "warm" | "quiet" | "noir" | "gothic";
+}

--- a/components/screens/GuidePicker.tsx
+++ b/components/screens/GuidePicker.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useAppStore, actions } from "@/lib/store";
+import { Mascot } from "@/components/mascots/Mascot";
+
+interface Guide {
+  id: string;
+  name: string;
+  tagline: string;
+  mascot: string;
+}
+
+export function GuidePicker({ guides = [] }: { guides?: Guide[] }) {
+  const [{ draft }, dispatch] = useAppStore();
+
+  const handleSelect = (guideId: string) => {
+    dispatch(actions.patchDraft({ guide_id: guideId }));
+    dispatch(actions.nextStep());
+  };
+
+  return (
+    <div className="stage animate-fade-in">
+      <div className="max-w-4xl mx-auto space-y-12">
+        <h1 className="h-display text-center smaller">Who should guide you?</h1>
+        
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+          {guides.map((guide) => (
+            <button
+              key={guide.id}
+              onClick={() => handleSelect(guide.id)}
+              className="plate flex flex-col items-center gap-6 text-center hover:-translate-y-1 transition-transform"
+            >
+              <div className="w-32 h-32">
+                {/* @ts-expect-error MascotId mapping */}
+                <Mascot id={guide.mascot} emotion="listening" />
+              </div>
+              <div>
+                <h3 className="font-serif text-2xl font-medium mb-2">{guide.name}</h3>
+                <p className="body-prose text-sm">{guide.tagline}</p>
+              </div>
+            </button>
+          ))}
+          
+          <button
+            onClick={() => handleSelect("custom")}
+            className="plate bare flex flex-col items-center justify-center gap-4 text-center hover:-translate-y-1 transition-transform"
+          >
+            <div className="w-16 h-16 rounded-full border-2 border-dashed border-current flex items-center justify-center text-2xl muted">
+              +
+            </div>
+            <h3 className="font-serif text-xl font-medium muted">Create your own</h3>
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/screens/PickMoment.tsx
+++ b/components/screens/PickMoment.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useState } from "react";
+import { useAppStore, actions } from "@/lib/store";
+
+const FEELINGS = [
+  "I want to celebrate them",
+  "I need to say I'm sorry",
+  "I want to confess something",
+  "I miss them so much",
+  "I'm feeling grateful",
+  "I just want to check in",
+];
+
+export function PickMoment() {
+  const [{ draft }, dispatch] = useAppStore();
+  const [text, setText] = useState("");
+  const [selectedFeeling, setSelectedFeeling] = useState<string | null>(null);
+
+  const handleNext = () => {
+    // Dispatch selected text and move to next step
+    dispatch(actions.patchDraft({ occasion: selectedFeeling || text }));
+    dispatch(actions.nextStep());
+  };
+
+  return (
+    <div className="stage animate-fade-in">
+      <div className="max-w-3xl mx-auto space-y-12">
+        <h1 className="h-display text-center">What brings you here?</h1>
+        
+        <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+          {FEELINGS.map((feeling) => (
+            <button
+              key={feeling}
+              onClick={() => setSelectedFeeling(feeling)}
+              className={`card text-left transition-all ${
+                selectedFeeling === feeling ? "selected" : ""
+              }`}
+            >
+              <div className="body-prose font-medium">{feeling}</div>
+            </button>
+          ))}
+        </div>
+
+        <div className="divider-flourish">
+          <span className="ornament-glyph">~</span>
+        </div>
+
+        <div className="space-y-4">
+          <label className="eyebrow block">Or tell us in your own words</label>
+          <textarea
+            className="textarea-prose ruled"
+            rows={4}
+            placeholder="I want to write a letter to my grandmother for her 80th birthday..."
+            value={text}
+            onChange={(e) => {
+              setText(e.target.value);
+              setSelectedFeeling(null);
+            }}
+          />
+        </div>
+
+        <div className="flex justify-end pt-8">
+          <button
+            onClick={handleNext}
+            disabled={!text && !selectedFeeling}
+            className="btn primary stamp"
+          >
+            Continue
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/screens/Render.tsx
+++ b/components/screens/Render.tsx
@@ -1,0 +1,244 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { SCRIPT } from "@/lib/demo";
+import { actions, useAppStore } from "@/lib/store";
+
+interface HoveredLine {
+  text: string;
+  src: string;
+  q: string;
+  a: string;
+}
+
+export function Render() {
+  const [, dispatch] = useAppStore();
+  const [hovered, setHovered] = useState<HoveredLine | null>(null);
+  const [pos, setPos] = useState({ x: 0, y: 0 });
+
+  useEffect(() => {
+    dispatch(actions.setEmotion("hopeful"));
+  }, [dispatch]);
+
+  // Final lines: the cliché was cut during drafting.
+  const finalLines = SCRIPT.draft.filter((d) => d.verified);
+
+  // Map "q3" -> SCRIPT.interview[2].
+  const lineToQA = (src: string | null) => {
+    if (!src) return null;
+    const idx = parseInt(src.replace(/^q/, ""), 10) - 1;
+    return SCRIPT.interview[idx] ?? null;
+  };
+
+  return (
+    <div
+      className="stage"
+      style={{ maxWidth: 760, paddingTop: 64, position: "relative" }}
+    >
+      <div className="corner-stamp">
+        <div className="postmark">
+          <div className="pm-top">verified · yours</div>
+          <div className="pm-mid">100%</div>
+          <div className="pm-bot">mean it · 2025</div>
+        </div>
+      </div>
+
+      <div style={{ textAlign: "center", marginBottom: 36 }}>
+        <div className="eyebrow">for tomas · read aloud, saturday</div>
+        <div className="ornament" style={{ marginTop: 12 }}>
+          <svg
+            width={120}
+            height={14}
+            viewBox="0 0 120 14"
+            style={{ display: "inline" }}
+          >
+            <path
+              d="M 4 7 Q 30 2, 60 7 T 116 7"
+              stroke="currentColor"
+              strokeWidth={1}
+              fill="none"
+            />
+            <circle cx={60} cy={7} r={2} fill="currentColor" />
+          </svg>
+        </div>
+      </div>
+
+      <article
+        style={{
+          fontFamily: "var(--t-body)",
+          fontSize: 24,
+          lineHeight: 1.75,
+          textAlign: "center",
+          color: "var(--t-ink)",
+        }}
+      >
+        {finalLines.map((ln, i) => {
+          const qa = lineToQA(ln.src);
+          return (
+            <div
+              key={i}
+              className="trace-line"
+              style={{
+                marginBottom: i === finalLines.length - 2 ? 18 : 4,
+              }}
+              onMouseEnter={(e) => {
+                if (qa && ln.src) {
+                  setHovered({
+                    text: ln.text,
+                    src: ln.src,
+                    q: qa.q,
+                    a: qa.a,
+                  });
+                  setPos({ x: e.clientX, y: e.clientY });
+                }
+              }}
+              onMouseMove={(e) => setPos({ x: e.clientX, y: e.clientY })}
+              onMouseLeave={() => setHovered(null)}
+            >
+              {ln.text}
+            </div>
+          );
+        })}
+      </article>
+
+      <div className="divider-flourish" style={{ marginTop: 64 }}>
+        <span className="ornament-glyph">❦</span>
+      </div>
+
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "center",
+          alignItems: "center",
+          gap: 14,
+          marginBottom: 8,
+        }}
+      >
+        <div className="seal" style={{ width: 44, height: 44 }}>
+          <span className="seal-glyph" style={{ fontSize: 18 }}>
+            M
+          </span>
+        </div>
+        <div
+          className="serif-italic"
+          style={{ fontSize: 22, color: "var(--t-ink)" }}
+        >
+          One hundred percent your words.
+        </div>
+      </div>
+      <div
+        className="muted"
+        style={{
+          fontFamily: "var(--t-mono)",
+          fontSize: 10,
+          textAlign: "center",
+          letterSpacing: "0.14em",
+        }}
+      >
+        every line · hover · see the question that prompted it
+      </div>
+
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "center",
+          gap: 10,
+          marginTop: 28,
+          flexWrap: "wrap",
+        }}
+      >
+        <button
+          className="btn ghost sm"
+          onClick={() => dispatch(actions.setModal("download"))}
+        >
+          ↓ download
+        </button>
+        <button
+          className="btn ghost sm"
+          onClick={() => dispatch(actions.setModal("save"))}
+        >
+          ♡ save
+        </button>
+        <button
+          className="btn ghost sm"
+          onClick={() => dispatch(actions.setModal("share"))}
+        >
+          ↗ share trace
+        </button>
+        <button
+          className="btn sm"
+          onClick={() => dispatch(actions.setModal("startover"))}
+        >
+          start over
+        </button>
+      </div>
+
+      {hovered && (
+        <div
+          className="trace-pop"
+          style={{
+            left: Math.min(
+              pos.x + 16,
+              (typeof window !== "undefined" ? window.innerWidth : 1024) - 340,
+            ),
+            top: Math.max(pos.y - 100, 20),
+          }}
+        >
+          <div className="eyebrow" style={{ color: "var(--t-accent)" }}>
+            trace · {hovered.src}
+          </div>
+          <div
+            className="muted"
+            style={{
+              fontFamily: "var(--t-mono)",
+              fontSize: 9,
+              marginTop: 8,
+            }}
+          >
+            question
+          </div>
+          <div
+            className="serif-italic"
+            style={{ fontSize: 14, marginTop: 2, color: "var(--t-ink)" }}
+          >
+            &ldquo;{hovered.q}&rdquo;
+          </div>
+          <div
+            className="muted"
+            style={{
+              fontFamily: "var(--t-mono)",
+              fontSize: 9,
+              marginTop: 10,
+            }}
+          >
+            your verbatim answer
+          </div>
+          <div
+            style={{
+              fontSize: 13,
+              marginTop: 4,
+              color: "var(--t-ink-soft)",
+              fontStyle: "italic",
+            }}
+          >
+            &ldquo;{hovered.a}&rdquo;
+          </div>
+          <div
+            style={{
+              marginTop: 12,
+              paddingTop: 10,
+              borderTop: "1px solid var(--t-ink-ghost)",
+              fontFamily: "var(--t-mono)",
+              fontSize: 9,
+              color: "var(--t-verified)",
+              letterSpacing: "0.1em",
+              textTransform: "uppercase",
+            }}
+          >
+            ✓ exact substring · verified yours
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/screens/Spine.tsx
+++ b/components/screens/Spine.tsx
@@ -1,0 +1,206 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import type {
+  DemoSpineCandidate,
+  DemoStructureMovement,
+} from "@/lib/demo";
+import { actions, useAppStore } from "@/lib/store";
+
+interface SpineResponse {
+  candidates: DemoSpineCandidate[];
+  structure: DemoStructureMovement[];
+}
+
+export function Spine() {
+  const [, dispatch] = useAppStore();
+  const [data, setData] = useState<SpineResponse | null>(null);
+  const [pickIdx, setPickIdx] = useState(0);
+
+  useEffect(() => {
+    dispatch(actions.setEmotion("moved"));
+  }, [dispatch]);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/api/spine", { method: "POST" })
+      .then((r) => r.json())
+      .then((d: SpineResponse) => {
+        if (!cancelled) setData(d);
+      })
+      .catch(() => {
+        // Stub mode — silently fall through; UI shows the loading state.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (!data) {
+    return (
+      <div className="stage">
+        <div
+          className="muted"
+          style={{ fontFamily: "var(--t-mono)", fontSize: 11 }}
+        >
+          listening for the spine…
+        </div>
+      </div>
+    );
+  }
+
+  const { candidates, structure } = data;
+
+  return (
+    <div className="stage">
+      <div className="eyebrow">spine · the line everything else hangs from</div>
+      <h1
+        className="h-display smaller"
+        style={{ marginTop: 8, marginBottom: 8 }}
+      >
+        Three of your phrases.
+        <br />
+        One of them is the heart.
+      </h1>
+      <div className="body-prose" style={{ maxWidth: 580, marginBottom: 28 }}>
+        Every phrase below is your verbatim text. Pick the one this letter is
+        built around.
+      </div>
+
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "1fr 1fr 1fr",
+          gap: 14,
+        }}
+      >
+        {candidates.map((c, i) => (
+          <button
+            key={c.source_turn_id}
+            onClick={() => setPickIdx(i)}
+            className={"card " + (pickIdx === i ? "selected" : "outlined")}
+            style={{
+              textAlign: "left",
+              cursor: "pointer",
+              padding: "20px 22px",
+              fontFamily: "inherit",
+              color: "inherit",
+              minHeight: 200,
+              display: "flex",
+              flexDirection: "column",
+              justifyContent: "space-between",
+            }}
+          >
+            <div>
+              <div className="eyebrow">
+                phrase {String(i + 1).padStart(2, "0")}
+              </div>
+              <div
+                className="serif-italic"
+                style={{
+                  fontSize: 22,
+                  lineHeight: 1.3,
+                  marginTop: 10,
+                  color: "var(--t-ink)",
+                }}
+              >
+                &ldquo;{c.text}&rdquo;
+              </div>
+            </div>
+            <div
+              className="muted"
+              style={{
+                fontFamily: "var(--t-mono)",
+                fontSize: 10,
+                marginTop: 16,
+              }}
+            >
+              {pickIdx === i
+                ? "● this is the spine"
+                : "from · " + c.source_label}
+            </div>
+          </button>
+        ))}
+      </div>
+
+      <div className="divider-flourish" />
+
+      <div className="eyebrow" style={{ marginBottom: 12 }}>
+        structure the guide proposes — three movements
+      </div>
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(3, 1fr)",
+          gap: 14,
+        }}
+      >
+        {structure.map((s) => (
+          <div
+            key={s.label}
+            className="card outlined"
+            style={{ padding: "18px 22px" }}
+          >
+            <div className="eyebrow" style={{ color: "var(--t-accent)" }}>
+              movement
+            </div>
+            <div
+              className="serif-italic"
+              style={{ fontSize: 22, marginTop: 6, color: "var(--t-ink)" }}
+            >
+              {s.label}
+            </div>
+            <div
+              className="muted"
+              style={{
+                fontFamily: "var(--t-mono)",
+                fontSize: 10,
+                marginTop: 4,
+              }}
+            >
+              {s.sub}
+            </div>
+            <div
+              style={{
+                marginTop: 16,
+                padding: "14px 12px",
+                border: "1px dashed var(--t-ink-faint)",
+                borderRadius: "var(--t-radius)",
+                fontFamily: "var(--t-mono)",
+                fontSize: 10,
+                color: "var(--t-ink-faint)",
+                textAlign: "center",
+                letterSpacing: "0.1em",
+                textTransform: "uppercase",
+              }}
+            >
+              your words · go here
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          marginTop: 36,
+        }}
+      >
+        <span
+          className="muted"
+          style={{ fontFamily: "var(--t-mono)", fontSize: 11 }}
+        >
+          swap or drop any movement · this is yours
+        </span>
+        <button
+          className="btn primary"
+          onClick={() => dispatch(actions.nextStep())}
+        >
+          start writing →
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -1,0 +1,47 @@
+# Design — letterpress / stationery identity
+
+Hi-fi prototype for Mean It, exported from Claude Design. Reference for the production port on `feat/sprint-1-design-refresh`. **Replaces the older lo-fi pack at `docs/wireframes/` (Pruthvi's PR #19) — the live components driven by that pack will be torn out as part of the refresh.**
+
+## Identity in one paragraph
+
+Letterpress / postal stationery. Display: Playfair Display (italic-leaning), Body: EB Garamond, UI: JetBrains Mono, Stamps: Special Elite. Five themes (cute → warm → quiet → noir → gothic) override ~30 CSS vars each — color, typography, ornament, animation speed, paper texture. Cards are debossed *plates*; buttons are stamped impressions; the byline is a wax seal pip; the artifact ships with a circular postmark. Real paper grain via layered SVG fractal noise.
+
+## Files
+
+| Path | Purpose |
+|---|---|
+| `hifi/Mean It Prototype.html` | Entry point. Loads React + Babel inline; mounts `<App/>`. Six-step flow + modal stack. |
+| `hifi/theme.css` | Design vocabulary. 5 theme blocks × ~30 vars each + the letterpress / postal patterns. |
+| `hifi/screens-1.jsx` | `PickMoment`, `GuidePicker`, `Interview` + the **SCRIPT** eulogy demo data (Tomas / the radio / "world is wide and the kitchen is small"). |
+| `hifi/screens-2.jsx` | `Spine`, `Drafting`, `Render`. |
+| `hifi/screens-3.jsx` | `CreateGuideDialog` — guided 5-question interview → preview/edit → stamp & share. |
+| `hifi/modals.jsx` | `DownloadDialog`, `SaveDialog`, `ShareDialog`, `StartOverDialog`, `ImageCardDialog`. |
+| `hifi/reel.jsx` | Reel composer (5-step). **Reference only — lives under d3v07's track (#10, area:audio-video).** |
+| `hifi/mascots.jsx` | Wren / Pip / Cassio — hand-drawn ink-line, 6 emotions each (`listening`, `curious`, `moved`, `sad`, `hopeful`, `silence`). |
+| `chat-transcript.md` | Full back-and-forth with the design assistant — read for intent and locked decisions. |
+
+## Locked design decisions (from chat-transcript.md)
+
+- **Theme = (e) full theatrical** — color + type + texture + ornament + ambient motion
+- **Mascot = hand-drawn ink-line**, 6 emotions, 3 built-ins paired with the 3 guides but decoupled (any mascot with any guide)
+- **PickMoment** = B+C hybrid (feeling cards → conversational textarea → AI-parsed pills)
+- **GuidePicker** = variant C (abstract glyph card with mascot inside)
+- **Interview** = variant A (classic split, mascot left + textarea right)
+- **Drafting** = variant A (streaming critique pane right)
+- **Render** = full-bleed centered, hover-only trace, postmark + wax seal
+- **Demo seed** = eulogy (heavier, lands harder, gothic/quiet theme spotlight)
+
+## Reading order
+
+1. `chat-transcript.md` — skim for the decisions table above.
+2. `hifi/theme.css` — internalize the tokens (5 themes × ~30 vars each + letterpress patterns).
+3. `hifi/screens-1.jsx` → `screens-2.jsx` → `screens-3.jsx` → `modals.jsx` — walk the flow.
+4. `hifi/mascots.jsx` — single SVG per creature, eyes/mouth shift per emotion.
+5. `hifi/reel.jsx` — only if reviewing the reel pipeline (d3v07's scope).
+
+## Notes for the port
+
+- The prototype uses React + Babel-in-browser and global `window` pollution (`Object.assign(window, ...)`). The production port uses Next.js components + ES module imports.
+- The `SCRIPT` object in `screens-1.jsx` is hardcoded demo data — the port should keep it as a fallback / demo seed but render real session state when available.
+- Theme is applied as a `theme-{id}` class on the `<App>` root; CSS vars cascade. The port keeps this approach (no JS theme math).
+- Mascot art lives in client-side SVG components; server emits `Guide.id` and the client maps to a mascot.

--- a/docs/design/chat-transcript.md
+++ b/docs/design/chat-transcript.md
@@ -1,0 +1,832 @@
+# Personalized Design System
+
+_Started 2026-04-26 15:30 UTC_
+
+---
+
+## User
+
+this is the idea and we need to create a design around it what is your suggestion,
+these are the points of my designer
+FrontEnd Ideas:
+    Page theme based off of users, set using a slider that can go from Cute to Gothic or any other preferences like manly to feminine
+    Duolingo Style Guide or Text Bubble Character that matches the users preferences and acts as a helping hand providing Extensions of the users ideas
+    Visual Representation of the changes in the ideas
+
+## Assistant
+
+I'll help you design Mean It. Before I dive in, let me ask a few questions to make sure the wireframes hit the right targets — your designer's ideas (theme slider, character guide, visual change history) are interesting and I want to know how to weight them against the core flow.
+
+_[tool: questions_v2]_
+
+## User
+
+Questions answered:
+- scope: All of the above
+- tone: Playful and customizable (lean into the theme slider)
+- designer_ideas: Theme slider (Cute↔Gothic etc.) — show as a real feature, Character/mascot guide (Duolingo-style) — show as a real feature, Visual change history of the artifact — show as a real feature, I want your honest take on which fit and which don't
+- mascot_concern: Show both directions side-by-side
+- fidelity: Mix — sketchy for exploration, mid-fi for the chosen direction
+- byline_emphasis: Subtle until hover — let the artifact breathe
+- interview_layout: 2
+- render_treatment: The artifact itself, full-bleed, beautiful typography. Trace is hover-only.
+
+## Assistant
+
+I've got what I need. Let me lay out the plan and start wireframing.
+
+**My take on the three designer ideas, honestly:**
+1. **Theme slider (Cute↔Gothic)** — Strong fit. The user already chose to lean into it. It maps emotionally to occasion (Gothic for eulogy, Cute for kid's birthday card, etc.) and gives the product a unique signature. **Keep, feature prominently.**
+2. **Mascot guide** — Risky for eulogies/apologies. I'll show it side-by-side with a quieter "guide-as-typography" alternative so we can compare. **Show both.**
+3. **Visual change history** — Useful, but the *provenance trace* already does this work for the final artifact. I'll wireframe it as a "drafting timeline" on the writing screen — scrub through your own edits — so it complements rather than duplicates.
+
+**Plan:**
+- Single HTML file using design_canvas to lay out all screens at low/mid-fi
+- Sketchy hand-drawn style for exploration (Caveat/Kalam font), b&w with one accent
+- Sections by screen, multiple variations per screen
+- Then a "chosen direction" mid-fi pass for the hero flow
+
+_[tool: update_todos]_
+
+_[tool: copy_starter_component]_
+
+_[tool: snip]_
+
+Let me check the design canvas component briefly, then build.
+
+_[tool: read_file]_
+
+Got it. Let me build the wireframes. I'll create a single HTML file with the design canvas hosting all screen variations.
+
+_[tool: write_file]_
+
+Now the wireframe components — split into a few files for sanity.
+
+_[tool: write_file]_
+
+Now the screen wireframes. I'll split into a few files.
+
+_[tool: write_file]_
+
+_[tool: write_file]_
+
+_[tool: snip]_
+
+_[tool: write_file]_
+
+_[tool: snip]_
+
+_[tool: write_file]_
+
+_[tool: done]_
+
+_[tool: snip]_
+
+_[tool: fork_verifier_agent]_
+
+Wireframes are ready — open the canvas to pan/zoom across all 9 sections.
+
+**What's in there**
+- **Intro card** with my honest read on your designer's three ideas
+- **6 product screens**, 2–3 directions each (sketchy, hand-drawn)
+- **Theme spectrum** — the slider treated as a real feature with 5 mini-previews of the same poem
+- **Create-your-own-guide + share import** — including the guardrail re-injection moment
+- **Mid-fi pass** on the chosen direction (interview + render)
+
+**Key calls I made — push back on any of these**
+1. **Theme slider → featured.** Single spectrum (cute → warm → quiet → noir → gothic), shifts both visuals *and* guide tone.
+2. **Mascot → shown 3 ways** (none / cartoon / abstract glyph). My recommendation is the abstract glyph — present without performing during somber moments.
+3. **Visual change history → drafting timeline.** Scrub through your own edits; complements the provenance trace rather than duplicating it.
+4. **Byline meter** — subtle in chrome (top-right), full glory only on render via hover trace.
+
+**Suggested next steps**
+- Pick a guide-picker direction (A/B/C) and a drafting direction (A/B/C) and I'll do a full mid-fi pass on the rest of the flow
+- Or: prototype the theme slider live so you can drag it and watch the page transform
+
+## User
+
+Theme slider → featured. Single spectrum (cute → warm → quiet → noir → gothic), shifts both visuals and guide tone.
+
+themes can be more elaborate but I like the initial wireframe
+mascot can be sad also right we can have some inbuilt and fetched thingys right?
+
+give me a todo, what you need from me now to freeze the design
+
+## Assistant
+
+_[tool: snip]_
+
+You're right — mascots can absolutely have emotional range. A sad mascot for a eulogy *is* the right register, and we can mix built-ins with user-fetched ones (URL-shared, just like guides). Let me give you a clean todo to freeze the design.
+
+---
+
+## ✅ Decisions locked
+- **Theme slider** featured (more elaborate treatments OK)
+- **Mascot** stays — but **emotion-aware** (it can be sad, quiet, hopeful) and **extensible** (built-ins + fetched-via-URL, same shareable pattern as guides)
+- **Drafting timeline** stays as a real feature
+- **Render** = full-bleed artifact, hover-only trace
+- **Byline meter** subtle in chrome
+
+## 🟡 What I need from you to freeze the design
+
+### 1. Theme — how elaborate?
+Pick one or describe:
+- (a) **Just color + type** (current treatment)
+- (b) **+ background textures** (paper grain for warm, ink wash for gothic, pastel for cute)
+- (c) **+ ornament** (corner flourishes, drop caps, dividers per theme)
+- (d) **+ ambient motion** (cute = float, gothic = slow fade, noir = grain)
+- (e) **All of the above — go theatrical**
+
+### 2. Mascot system — emotion + sourcing
+- **How many emotional states** per mascot? (e.g. neutral / listening / moved / sad / curious — 3? 5? 7?)
+- **Built-in mascot count?** (3 to match the 3 guides? or one mascot per theme = 5? or decoupled — pick any mascot with any guide?)
+- **Fetched mascots** — same URL-payload pattern as guides? (encoded SVG + emotion map → import)
+- **When does emotion change?** (a) per question type, (b) when user writes something striking, (c) when guide flags a cliché, (d) all of the above
+
+### 3. Pick the moment — direction (A/B/C)?
+A = form-first, B = conversational parse, C = feeling-first
+
+### 4. Guide picker — direction (A/B/C)?
+A = typography only, B = full mascot, C = abstract glyph
+(Given mascots are in: probably **B**, but confirm)
+
+### 5. Interview — direction (A/B/C)?
+A = classic split, B = chat + holding pane, C = one-question focus
+
+### 6. Drafting — direction (A/B/C)?
+A = streaming critique, B = drafting timeline, C = single critique
+(Timeline is locked-in as a feature; this is about where it lives — own panel vs. modal vs. always-on)
+
+### 7. Mascot art direction
+- (a) **Abstract blobs** with eyes (current)
+- (b) **Hand-drawn ink creatures** (more character)
+- (c) **Geometric figures** (cleaner, less "AI slop")
+- (d) **Reference style I'll send you**
+
+### 8. Demo seed for the hi-fi mock?
+Birthday-for-grandma (current) or eulogy (heavier)?
+
+---
+
+Reply with answers to **1, 2, 3, 4, 5, 6, 7, 8** (even partial — "decide for me" works) and I'll move to a full hi-fi prototype with the theme slider live, mascot emotional states animating, and the chosen flow end-to-end.
+
+## User
+
+1. theme e
+2. How many emotional states per mascot? (e.g. neutral / listening / moved / sad / curious — 3? 5? 7?)
+A: 5-6 emotions balanced b/w 
+Built-in mascot count? (3 to match the 3 guides? or one mascot per theme = 5? or decoupled — pick any mascot with any guide?)
+we can match mascots w emotions ideally or guides or both
+Fetched mascots — same URL-payload pattern as guides? (encoded SVG + emotion map → import)
+When does emotion change? (a) per question type, (b) when user writes something striking, (c) when guide flags a cliché, (d) all of the above
+Pick the moment — direction (A/B/C)?
+a mix of B and C B = conversational parse, C = feeling-first
+
+A = typography only, B = full mascot, C = abstract glyph (Given mascots are in: probably B, but confirm)
+
+C
+
+5. Interview — direction (A/B/C)?
+A = classic split, B = chat + holding pane, C = one-question focus
+A classic split
+
+6. Drafting — direction (A/B/C)?
+A = streaming critique, 
+7. Mascot art direction
+(a) Abstract blobs with eyes (current)
+(b) Hand-drawn ink creatures (more character)
+(c) Geometric figures (cleaner, less "AI slop")
+(d) Reference style I'll send you
+
+idk decide for me or we discuss more
+
+
+8. Demo seed for the hi-fi mock?
+Birthday-for-grandma (current) or eulogy (heavier)?
+
+eulogy
+
+## Assistant
+
+_[tool: snip]_
+
+Locked. Here's where I land on each open question, then I'll build.
+
+**Mascot art direction** — going with **(b) hand-drawn ink creatures**, but on the *minimal* end: simple ink-line silhouettes (think: a single continuous brushstroke creature), not detailed illustration. Reasons:
+- Geometric figures (c) feel cold for a tool used for eulogies
+- Abstract blobs (a) read as "AI assistant" — exactly the trope to avoid
+- Hand-drawn ink matches the sketchy/literary aesthetic and gives room for genuine emotional states (a sad creature should look sad, not be a smiley with a different mouth)
+- 6 emotions per mascot: **listening, curious, moved, sad, hopeful, holding-silence**
+- 3 built-in mascots, each paired with a guide *and* a default theme, but **decoupled** — any mascot can run any guide; the emotion map is what couples them to the moment
+
+**Theme (e)** — full theatrical: color + type + texture + ornament + subtle ambient motion. Eulogy demo means the gothic end gets the spotlight.
+
+**Locked flow:** Pick-the-moment B+C hybrid → Guide picker C (abstract glyph but with mascot inside the card) → Interview A (classic split) → Spine → Drafting A (streaming critique) → Render full-bleed → Trace on hover.
+
+**Demo seed:** Eulogy. The grandfather demo. Heavier, lands harder, and the gothic theme + sad-mascot moment is the differentiator no other hackathon project will have.
+
+I'll build a hi-fi prototype now — single file, theme slider live and dragable, mascot emotional states animating, full eulogy flow walkthrough.
+
+_[tool: update_todos]_
+
+_[tool: snip]_
+
+Building the hi-fi now. I'll set up the theme system + mascots first, then assemble the full eulogy flow.
+
+_[tool: write_file]_
+
+_[tool: snip]_
+
+_[tool: write_file]_
+
+_[tool: snip]_
+
+_[tool: write_file]_
+
+_[tool: snip]_
+
+_[tool: write_file]_
+
+_[tool: snip]_
+
+_[tool: write_file]_
+
+_[tool: snip]_
+
+_[tool: done]_
+
+_[tool: snip]_
+
+_[tool: fork_verifier_agent]_
+
+Hi-fi prototype is ready. Walk through all 6 steps via the breadcrumbs in the header, drag the **theme slider** (top-right) to feel the same flow under five different emotional registers — gothic is the recommended demo theme for the eulogy seed.
+
+**What's working live:**
+- Theme slider with full theatrical treatment (color, type, texture, ornament, ambient mascot motion)
+- 3 mascots × 6 emotions, ink-line, decoupled — Wren is paired with documentarian by default
+- Mascot emotion shifts per question, on cliché flag, and on render
+- Eulogy flow seeded end-to-end: Tomas, the radio, "world is wide and the kitchen is small"
+- Streaming critique: simulated typing, cliché flag on "forever in our hearts", verified-yours marks on real lines
+- Render screen: hover any line → trace popover with the question + your verbatim words
+
+**Suggested next iterations:**
+- Create-your-own-guide flow (still wireframe-only)
+- Share-link import screen
+- Mobile pass
+- Real Claude wiring (claude.complete) — replace simulated typing with live streams
+
+## User
+
+Verifier agent check completed
+
+## Assistant
+
+_[tool: snip]_
+
+_[tool: grep]_
+
+_[tool: snip]_
+
+_[tool: str_replace_edit]_
+
+_[tool: str_replace_edit]_
+
+_[tool: snip]_
+
+_[tool: done]_
+
+_[tool: snip]_
+
+_[tool: fork_verifier_agent]_
+
+_[tool: snip]_
+
+Both verifier issues fixed: draft text now uses `var(--t-ink)` so it stays legible on noir/gothic, and the render footer is no longer fixed (sits at bottom of stage, no overlap).
+
+Drag the theme slider to gothic on the drafting and render screens — should now be readable across the full spectrum.
+
+## User
+
+Save this design as a PDF: hifi/Mean It Prototype.html
+
+## Assistant
+
+_[tool: snip]_
+
+_[tool: read_file]_
+
+I'll create a print-ready version that renders all 6 screens stacked, one per page, in the gothic theme (the chosen demo direction).
+
+_[tool: snip]_
+
+_[tool: write_file]_
+
+_[tool: snip]_
+
+_[tool: show_html]_
+
+_[tool: snip]_
+
+_[tool: show_html]_
+
+_[tool: snip]_
+
+_[tool: get_webview_logs]_
+
+_[tool: snip]_
+
+_[tool: open_for_print]_
+
+_[tool: snip]_
+
+The print-ready file is set to auto-print all 6 screens in the gothic theme — open the link, dismiss the print dialog if you want to preview first, then Cmd/Ctrl+P → Save as PDF.
+
+[Open Mean It Prototype-print.html](https://019dca69-a37c-70ca-ad5a-22481a491080.claudeusercontent.com/v1/design/projects/019dca69-a37c-70ca-ad5a-22481a491080/serve/hifi/Mean%20It%20Prototype-print.html?t=d692bd5d203e8a704287e8d33ef8720d296f8e78d6cfdacc8e51cee1bfc2e647.0cd546f2-32f6-4ab5-8144-d7e4146e4a86.ce592a45-3e77-4dc6-beaf-13ec07fe0a1c.1777227077)
+
+## User
+
+so we were wireframing it now can we have this as a full design, and I like the way it looks but it looks like claude itslef can we do soemthing
+also things I need,
+a design for create your own guide and the entire flow you can ask questions for clarity,
+Pages,
+I also need to design pages for 
+↓ download
+♡ save
+↗ share trace
+start over ideas.
+so yes lets proceed to complete this
+
+## Assistant
+
+_[tool: snip]_
+
+Good direction. Let me ask a few sharp questions before I rebuild — the "looks like Claude itself" feedback is the most important one and I want to nail the visual identity shift.
+
+_[tool: snip]_
+
+_[tool: questions_v2]_
+
+## User
+
+Questions answered:
+- identity_shift: The literary serif feels too 'Claude-style' minimal, The whole thing reads as 'corporate AI tool', The design does not instill a feeling of being creative, the minimalist pattern does not make me feel like writing but giving rigid answers that conform to limited creativity 
+- vibe: Tactile/object-oriented — feels like a physical artifact (notebook, letter, telegram), Analog stationery — letterpress, ink, postage, postmarks, deckle edges, Something that feels like a creative space that is an extension of their own ideas
+- create_guide_depth: Hybrid — single screen but the 4–5 questions are a guided sequence inside it
+- create_guide_outputs: Result + editable raw fields (name, voice rules, sample questions)
+- signature_color: There will be a slider that enables the user to shift from a very cutesy theme to a dark gothic theme
+- download_format: All three (toolbar of formats)
+- typography: Serif display + monospace UI (literary + technical)
+- download_branding: Yes — visible 'Mean It' wordmark + 100% yours stamp
+- save_meaning: Save with a personal share-back link (anyone with link can read)
+- share_trace: Public/social — the artifact + a 'every word verified yours' badge
+- start_over: Decide for me
+- signature_motif: Letterpress impression / debossed look
+- mascot_intensity: Keep current ink-line mascots, restyle to match new identity
+- layout_density: Mixed — sparse for emotional moments, dense for decision moments
+- freeform: so we dont wanna move too much away from what we have got. but we wanna have an identitiy for this product visually, rest I think things are okay
+
+## Assistant
+
+_[tool: snip]_
+
+_[tool: snip]_
+
+_[tool: update_todos]_
+
+_[tool: list_files]_
+
+Let me clean up the stale todos and read the current files to understand what I'm building on.
+
+_[tool: update_todos]_
+
+_[tool: read_file]_
+
+_[tool: read_file]_
+
+_[tool: snip]_
+
+_[tool: read_file]_
+
+_[tool: read_file]_
+
+_[tool: read_file]_
+
+_[tool: snip]_
+
+Got it. Here's my plan — I'll shift the visual identity hard toward **physical artifact / letterpress stationery**, then build the four new flows. Working in stages so you can react.
+
+**Identity shift (the "doesn't feel like Claude" fix):**
+- Replace Cormorant Garamond (the give-away "AI literary serif") with **Playfair Display + EB Garamond** for a heavier, more printed feel — and pair with **JetBrains Mono** for the technical/byline UI
+- Add **letterpress impression** — subtle inset shadows, embossed/debossed plates on cards, paper-edge deckling
+- Add **stationery elements** — postmark stamps, postal tape, deckle paper edges, a "wax seal" accent that morphs across themes
+- Lean into **physical chrome** — header becomes a paper-tape/masking-tape strip; cards become **plates** (debossed); buttons become **stamped impressions**
+- Keep the theme slider, mascots (restyled as woodcut-leaning ink), and overall structure
+
+**New flows to build:**
+1. **Create-your-own-guide** (hybrid: 4 questions → live preview → editable raw fields)
+2. **Download** dialog (PDF / plain text / image card · Mean It wordmark + 100% yours stamp)
+3. **Save** screen (personal share-back link)
+4. **Share trace** screen (public/social with verification badge)
+5. **Start over** (smart confirmation that preserves the saved letter)
+
+_[tool: update_todos]_
+
+Let me start with the identity rebuild — new theme.css with letterpress, postal motifs, and richer typography.
+
+_[tool: write_file]_
+
+_[tool: snip]_
+
+_[tool: update_todos]_
+
+Now let me update the main HTML to include the new fonts and add the modal/overlay system, then start rebuilding screens.
+
+_[tool: str_replace_edit]_
+
+_[tool: snip]_
+
+_[tool: str_replace_edit]_
+
+_[tool: snip]_
+
+Now let me update the main App to add modal state and pass it to screens, then rebuild the existing screens with the letterpress identity.
+
+_[tool: str_replace_edit]_
+
+_[tool: snip]_
+
+_[tool: str_replace_edit]_
+
+_[tool: snip]_
+
+_[tool: snip]_
+
+Now let me update the Render screen to use the new modal callbacks and apply letterpress treatment:
+
+_[tool: str_replace_edit]_
+
+_[tool: snip]_
+
+_[tool: str_replace_edit]_
+
+<neverthink>
+
+_[tool: snip]_
+
+Now let me update the GuidePicker to wire up the create-your-own-guide button, then build screens-3.jsx (with the new Render footer/postmark) and modals.jsx with all five dialogs.
+
+_[tool: str_replace_edit]_
+
+_[tool: str_replace_edit]_
+
+<neverthink>
+
+_[tool: snip]_
+
+<neverthink>
+
+_[tool: snip]_
+
+Now let me upgrade the Render screen with letterpress treatment and a postmark, then build modals.jsx with all dialogs.
+
+_[tool: str_replace_edit]_
+
+_[tool: str_replace_edit]_
+
+<neverthink>
+
+_[tool: snip]_
+
+<neverthink>
+
+_[tool: snip]_
+
+<neverthink>
+
+_[tool: snip]_
+
+<neverthink>
+
+_[tool: snip]_
+
+<neverthink>
+
+_[tool: snip]_
+
+Now let me build modals.jsx (all 5 dialogs) and screens-3.jsx (the create-your-own-guide hybrid flow).
+
+_[tool: write_file]_
+
+<neverthink>
+
+_[tool: snip]_
+
+<neverthink>
+
+_[tool: snip]_
+
+_[tool: write_file]_
+
+<neverthink>
+
+_[tool: snip]_
+
+_[tool: update_todos]_
+
+_[tool: done]_
+
+<neverthink>
+
+_[tool: snip]_
+
+_[tool: fork_verifier_agent]_
+
+<neverthink>
+
+_[tool: snip]_
+
+The new identity is live and the four new flows are wired up. Here's what shipped:
+
+**Visual identity shift — away from "Claude AI"**
+- New typography: **Playfair Display** (italic, heavier display) + **EB Garamond** (warmer body) + **JetBrains Mono** (technical UI) + **Special Elite** (typewriter, used for stamps)
+- **Letterpress vocabulary**: debossed `.plate` cards (inset shadows, paper highlights/shadows), embossed buttons with ink-pressed feel
+- **Postal motifs**: paper-tape strip across the chrome header, postmark stamp on the rendered artifact, wax-seal byline pip with the soft glow + drip clip-path, deckle paper edges
+- **Real paper texture**: layered fractal-noise grain + fiber turbulence on every surface, multiply/screen blends per theme
+- Postal-red signature color in warm theme (replaces the orange that read as "AI assistant")
+- Theme slider keeps the full spectrum — colors, textures, ornaments, ambient motion all shift
+
+**Four new flows (`modals.jsx` + `screens-3.jsx`)**
+1. **Download** — format picker (PDF / plain text / image card) with live preview, toggles for the Mean It wordmark stamp + provenance appendix, "delivered" stamp on completion
+2. **Save** — title input, private/unlisted radio, share-back link with copy button, "saved · [date]" stamp
+3. **Share trace** — three audience modes (recipient / public / audit) each with a different preview of what the receiver sees, then sealed share link + send-to-channel buttons
+4. **Start over** — confirmation that reassures the current letter is safe in the library, mentions the "different letter for the same person" path
+5. **Create-your-own-guide** (hybrid) — single dialog with 5-step guided sequence (pulls for / voice / sample question / never / name) + live forming preview, then editable raw fields side-by-side with the finished guide card, then a stamp+share screen
+
+**Open next steps**
+- Mascot art could push further toward woodcut/linocut to match the new identity (currently still ink-line)
+- Mobile pass on dialogs
+- Real Claude wiring on drafting + create-guide
+
+## User
+
+Verifier agent check completed
+
+## Assistant
+
+<neverthink>
+
+_[tool: snip]_
+
+_[tool: str_replace_edit]_
+
+_[tool: str_replace_edit]_
+
+<neverthink>
+
+_[tool: snip]_
+
+_[tool: done]_
+
+<neverthink>
+
+_[tool: snip]_
+
+_[tool: fork_verifier_agent]_
+
+<neverthink>
+
+_[tool: snip]_
+
+<neverthink>
+
+Both verifier issues fixed:
+- Logo no longer wraps (`white-space: nowrap` + `flex-shrink: 0`)
+- Modal scrim now fully covers the chrome (z-index raised to 200)
+
+Try opening any of the four new flows from the render screen, plus "Create your own guide" from the guide picker — they should now sit cleanly over the page.
+
+## User
+
+Once whole workflow runs, The output that user gets can be used  to create image as per the occasion and also can be converted to a short reel
+which has this is the ideation
+Reel pipeline (the vertical 9:16 MP4)
+#	Feature	Frontend	Backend / API route	AI / Model	Storage / External
+13	Photo upload	Drag-drop uploader, gallery	/api/photos/upload → forwards to Anthropic Files API	—	Anthropic Files (file_id); thumbnails as blob URLs
+14	Photo Reader	invisible (runs after upload)	/api/photos/describe	Sonnet 4.6 vision — Photo Reader; returns subject/setting/mood per photo	descriptions in Session.photos[]
+15	Voice recording	MediaRecorder UI w/ live waveform + retake	none (in-browser)	—	blob URL only; not uploaded
+15b	TTS fallback (no recording)	"Use synthesized voice" button	/api/tts	OpenAI gpt-4o-mini-tts	blob URL; tagged "Voice: synthesized"
+15c	Voice transcript (line timestamps)	invisible — needed to sync captions	/api/transcribe	OpenAI Whisper or browser SpeechRecognition (free)	line-by-line timestamps in Session
+16	Curator / Storyboarder	trigger on "Render reel"	/api/curator	Sonnet 4.6 — Curator; takes (poem, photo descriptions, voice duration + timestamps) → Storyboard JSON	storyboard in Session.reel
+17	Canvas renderer	<canvas> 1080×1920 @ 30fps; Web Animations API for Ken Burns + caption fades	none — pure client	—	renders to MediaRecorder stream
+18	Capture + transcode	canvas.captureStream(30) + audio track → webm; ffmpeg.wasm webm→mp4	none	—	output blob URL
+19	Download	<a download> link	none	—	client download
+
+## Assistant
+
+<neverthink>
+
+_[tool: snip]_
+
+<neverthink>
+
+_[tool: snip]_
+
+Great direction. The reel pipeline is a natural extension — the artifact already has all the data structures we need (verbatim lines, timestamps from interview, theme palette, mascot). Let me ask a few questions before designing the new screens, so I scope this right.
+
+_[tool: questions_v2]_
+
+## User
+
+Questions answered:
+- scope_now: All three — full design pass, Reel result screen — design now (post-render: preview, download, share), Reel composer flow — design now (photo upload → record voice → preview → export), Image card export — design now
+- image_card_styles: All of the above as a format picker
+- image_layouts: Letter on paper aesthetic (verbatim text on the artifact, postmark), Single hero line (one verbatim line, big type, theme palette), Photo + caption (user-uploaded photo as background, line overlaid), Carousel (multiple slides — moments, lines, trace)
+- reel_entry: From a dedicated 'make it move' CTA at the bottom of the artifact
+- reel_steps: Upload photos (drag-drop + gallery + AI auto-describe), Record voice (waveform UI, retake, TTS fallback), Preview the storyboard (curator's plan before render), Render preview (live canvas), Result screen (download, share, regenerate)
+- reel_voice: remove
+- storyboard_visibility: Show the storyboard — let user reorder/edit shot list
+- reel_aesthetic: Theme-aware (cute reel ≠ gothic reel, palette + motion change)
+- reel_export: MP4 download, Direct share to social (TikTok, IG, Twitter)
+- fidelity: Hi-fi (production-ready, fully styled)
+
+## Assistant
+
+<neverthink>
+
+_[tool: snip]_
+
+<neverthink>
+
+Got it. Plan locked:
+
+**Image card export** — format picker (1:1, 4:5, 9:16, 16:9, letter-style) × 4 layouts (letter-on-paper, hero line, photo+caption, carousel)
+
+**Reel flow** — 5 screens: photos → record voice (recording-only, no TTS) → storyboard editor → render preview → result. Theme-aware.
+
+Let me build this. Starting with the image card export dialog upgrade, then the reel flow.
+
+_[tool: update_todos]_
+
+_[tool: read_file]_
+
+<neverthink>
+
+_[tool: snip]_
+
+<neverthink>
+
+_[tool: snip]_
+
+<neverthink>
+
+_[tool: snip]_
+
+<neverthink>
+
+_[tool: snip]_
+
+<neverthink>
+
+_[tool: snip]_
+
+<neverthink>
+
+_[tool: snip]_
+
+<neverthink>
+
+I'll wire up the reel flow. Given the scope, I'll build it in a single new file with all 5 reel screens + the upgraded image-card export, then update the main App.
+
+_[tool: write_file]_
+
+<neverthink>
+
+_[tool: snip]_
+
+_[tool: update_todos]_
+
+_[tool: list_files]_
+
+<neverthink>
+
+_[tool: snip]_
+
+_[tool: grep]_
+
+<neverthink>
+
+_[tool: snip]_
+
+_[tool: read_file]_
+
+<neverthink>
+
+_[tool: snip]_
+
+_[tool: grep]_
+
+<neverthink>
+
+_[tool: snip]_
+
+_[tool: read_file]_
+
+<neverthink>
+
+I need to add the "make it move" CTA to the render screen and wire ReelFlow + ImageCardDialog into the app.
+
+_[tool: snip]_
+
+_[tool: str_replace_edit]_
+
+_[tool: str_replace_edit]_
+
+_[tool: str_replace_edit]_
+
+_[tool: str_replace_edit]_
+
+_[tool: str_replace_edit]_
+
+_[tool: str_replace_edit]_
+
+<neverthink>
+
+Now let me wire up the DownloadDialog → ImageCardDialog connection. Let me check the current DownloadDialog.
+
+_[tool: snip]_
+
+_[tool: grep]_
+
+<neverthink>
+
+_[tool: snip]_
+
+_[tool: read_file]_
+
+<neverthink>
+
+_[tool: snip]_
+
+<neverthink>
+
+_[tool: snip]_
+
+_[tool: read_file]_
+
+<neverthink>
+
+_[tool: snip]_
+
+_[tool: str_replace_edit]_
+
+_[tool: str_replace_edit]_
+
+_[tool: str_replace_edit]_
+
+_[tool: done]_
+
+<neverthink>
+
+_[tool: snip]_
+
+_[tool: update_todos]_
+
+_[tool: fork_verifier_agent]_
+
+<neverthink>
+
+The reel composer is wired in end-to-end — head to the render screen and click **▶ make a reel** in the new "Make it move" card to walk through photos → voice → storyboard → render → result. The download dialog's image card option also now opens the full format + layout picker.
+
+**What's live**
+- 5-step reel flow with sub-stepper, eulogy seed pre-loaded
+- Voice recording with live waveform, retake, transcription status
+- Editable storyboard (reorder shots, swap photos, see runtime)
+- 9:16 canvas preview with ken-burns + caption fades + end card
+- Result screen with mp4 download + social share + trace badge
+- Image card export: 5 formats × 4 layouts with live preview
+
+**Suggested next**
+- Wire real Claude vision for photo analysis on the photos step
+- Add a "draft caption from line" inline edit on the storyboard
+- Mobile pass on the reel flow specifically (it's currently desktop-tuned)
+
+## User
+
+Verifier agent check completed
+
+## Assistant
+
+_[tool: snip]_
+
+<neverthink>
+
+_[tool: snip]_
+
+<neverthink>
+
+_[tool: snip]_
+
+<neverthink>
+
+The reel composer is wired in end-to-end. Head to the render screen and click **▶ make a reel** to walk through photos → voice → storyboard → render → result. The download dialog's image card option now also opens the full format + layout picker.
+

--- a/docs/design/hifi/Mean It Prototype.html
+++ b/docs/design/hifi/Mean It Prototype.html
@@ -1,0 +1,158 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8"/>
+<title>Mean It — Hi-Fi Prototype</title>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,500;0,600;0,700;0,800;1,500;1,600;1,700&family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400;1,500&family=Fraunces:ital,opsz,wght@0,9..144,500;0,9..144,700;1,9..144,500&family=JetBrains+Mono:wght@400;500;600&family=Special+Elite&family=Caveat:wght@400;600;700&display=swap" rel="stylesheet"/>
+<link rel="stylesheet" href="theme.css"/>
+<style>
+  @keyframes blink { 50% { opacity: 0; } }
+  @keyframes fadein { from { opacity: 0; transform: translateY(4px); } to { opacity: 1; transform: none; } }
+</style>
+</head>
+<body>
+<div id="root"></div>
+
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+
+<script type="text/babel" src="mascots.jsx"></script>
+<script type="text/babel" src="screens-1.jsx"></script>
+<script type="text/babel" src="screens-2.jsx"></script>
+<script type="text/babel" src="screens-3.jsx"></script>
+<script type="text/babel" src="modals.jsx"></script>
+<script type="text/babel" src="reel.jsx"></script>
+
+<script type="text/babel">
+const THEMES = [
+  { id: 'cute',   label: 'cute',   sub: 'kid birthdays' },
+  { id: 'warm',   label: 'warm',   sub: 'family · default' },
+  { id: 'quiet',  label: 'quiet',  sub: 'apologies · letters' },
+  { id: 'noir',   label: 'noir',   sub: 'love · longing' },
+  { id: 'gothic', label: 'gothic', sub: 'eulogies · weight' },
+];
+
+const STEPS = [
+  { id: 'moment',    label: '01 · moment'    },
+  { id: 'guide',     label: '02 · guide'     },
+  { id: 'interview', label: '03 · interview' },
+  { id: 'spine',     label: '04 · spine'     },
+  { id: 'drafting',  label: '05 · drafting'  },
+  { id: 'render',    label: '06 · render'    },
+];
+
+function ThemeSlider({ theme, setTheme }) {
+  return (
+    <div className="theme-slider" data-screen-label="theme-slider">
+      <span className="label">theme</span>
+      <div className="track">
+        {THEMES.map(t => (
+          <button key={t.id}
+            className={'pip ' + (theme === t.id ? 'on' : '')}
+            onClick={() => setTheme(t.id)}
+            title={t.label + ' · ' + t.sub}
+            style={{ background: 'none', border: 'none', padding: 0 }}>
+            <span/>
+          </button>
+        ))}
+      </div>
+      <span className="label" style={{ minWidth: 44, textAlign: 'right' }}>{theme}</span>
+    </div>
+  );
+}
+
+function App() {
+  const [theme, setTheme] = React.useState('quiet'); // eulogy default
+  const [step, setStep] = React.useState('moment');
+  const [emotion, setEmotion] = React.useState('listening');
+  const [modal, setModal] = React.useState(null); // 'download'|'save'|'share'|'startover'|'createguide'|'reel'|'imagecard'|null
+
+  const stepIdx = STEPS.findIndex(s => s.id === step);
+  const next = () => {
+    const i = STEPS.findIndex(s => s.id === step);
+    if (i < STEPS.length - 1) setStep(STEPS[i+1].id);
+    else setStep('moment');
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  };
+
+  // theme moods — when entering eulogy flow, suggest gothic; etc. (subtle)
+  // we don't auto-switch — user controls.
+
+  // byline visibility: subtle in chrome on later steps
+  const showByline = ['drafting', 'render'].includes(step);
+
+  return (
+    <div className={'app theme-' + theme} data-screen-label={'mean-it ' + step}>
+      <div className="grain"/>
+      <header className="chrome">
+        <div style={{ display: 'flex', alignItems: 'center', gap: 22 }}>
+          <span className="logo">Mean It<span className="logo-dot">.</span></span>
+          <div className="crumbs">
+            {STEPS.map((s, i) => (
+              <button key={s.id}
+                className={'crumb ' + (s.id === step ? 'now' : '')}
+                onClick={() => setStep(s.id)}
+                style={{
+                  background: 'none', border: 'none', padding: 0, cursor: 'pointer',
+                  fontFamily: 'inherit', fontSize: 'inherit', letterSpacing: 'inherit',
+                  textTransform: 'inherit',
+                  color: s.id === step ? 'var(--t-ink)' : i < stepIdx ? 'var(--t-ink-soft)' : 'var(--t-ink-faint)',
+                  opacity: i <= stepIdx ? 1 : 0.5,
+                }}>
+                {s.label}
+              </button>
+            ))}
+          </div>
+        </div>
+        <div className="right">
+          {showByline && (
+            <div className="byline">
+              <span className="byline-dot"/>
+              <span>{step === 'render' ? '100% yours' : 'verifying as you write…'}</span>
+            </div>
+          )}
+          <ThemeSlider theme={theme} setTheme={setTheme}/>
+        </div>
+      </header>
+
+      {step === 'moment'    && <PickMoment go={next}/>}
+      {step === 'guide'     && <GuidePicker go={next} openCreateGuide={() => setModal('createguide')}/>}
+      {step === 'interview' && <Interview go={next} setEmotion={setEmotion}/>}
+      {step === 'spine'     && <Spine go={next} setEmotion={setEmotion}/>}
+      {step === 'drafting'  && <Drafting go={next} setEmotion={setEmotion}/>}
+      {step === 'render'    && <Render
+        setEmotion={setEmotion}
+        openDownload={() => setModal('download')}
+        openSave={() => setModal('save')}
+        openShare={() => setModal('share')}
+        openStartOver={() => setModal('startover')}
+        openReel={() => setModal('reel')}
+      />}
+
+      {modal === 'createguide' && <CreateGuideDialog onClose={() => setModal(null)}/>}
+      {modal === 'download'    && <DownloadDialog    onClose={() => setModal(null)} openImageCard={() => setModal('imagecard')}/>}
+      {modal === 'save'        && <SaveDialog        onClose={() => setModal(null)}/>}
+      {modal === 'share'       && <ShareDialog       onClose={() => setModal(null)}/>}
+      {modal === 'startover'   && <StartOverDialog   onClose={() => setModal(null)} confirm={() => { setModal(null); setStep('moment'); }}/>}
+      {modal === 'imagecard'   && <ImageCardDialog   onClose={() => setModal(null)}/>}
+      {modal === 'reel'        && <ReelFlow          onClose={() => setModal(null)} theme={theme}/>}
+
+      <footer style={{
+        marginTop: 48, padding: '32px 0 28px',
+        textAlign: 'center', fontFamily: 'var(--t-mono)', fontSize: 9,
+        color: 'var(--t-ink-faint)', letterSpacing: '0.18em', textTransform: 'uppercase',
+      }}>
+        every word is yours · we can prove it
+      </footer>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App/>);
+</script>
+</body>
+</html>

--- a/docs/design/hifi/mascots.jsx
+++ b/docs/design/hifi/mascots.jsx
@@ -1,0 +1,143 @@
+// Mean It hi-fi — mascot system. Hand-drawn ink-line, 6 emotional states.
+// Three built-in mascots: Wren (documentarian), Pip (poet), Cassio (songwriter).
+// All emotions for all mascots. Decoupled from guides so any pairing works.
+
+// Each mascot is a function(emotion) → JSX <svg>.
+// 6 emotions: listening | curious | moved | sad | hopeful | silence
+// Single ink-line aesthetic. Eyes + mouth shift; body silhouette stays.
+
+const STROKE = 'var(--t-ink)';
+
+const ink = (extra={}) => ({
+  fill: 'none',
+  stroke: STROKE,
+  strokeWidth: 1.4,
+  strokeLinecap: 'round',
+  strokeLinejoin: 'round',
+  ...extra,
+});
+
+// shared eye + mouth library — composed onto each silhouette
+function Eyes({ emotion, x1=26, x2=42, y=30, scale=1 }) {
+  const s = ink({ strokeWidth: 1.4 });
+  // listening — small dots, attentive
+  if (emotion === 'listening') return (
+    <g>
+      <circle cx={x1} cy={y} r={1.4} fill={STROKE}/>
+      <circle cx={x2} cy={y} r={1.4} fill={STROKE}/>
+    </g>
+  );
+  // curious — one slightly raised arch, small dots
+  if (emotion === 'curious') return (
+    <g>
+      <path d={`M ${x1-3} ${y-3} q 3 -2 6 0`} {...s}/>
+      <circle cx={x1} cy={y} r={1.4} fill={STROKE}/>
+      <circle cx={x2} cy={y} r={1.4} fill={STROKE}/>
+    </g>
+  );
+  // moved — soft closed-arc eyes (touched)
+  if (emotion === 'moved') return (
+    <g>
+      <path d={`M ${x1-3} ${y} q 3 2 6 0`} {...s}/>
+      <path d={`M ${x2-3} ${y} q 3 2 6 0`} {...s}/>
+    </g>
+  );
+  // sad — downturned arcs, small tear hint
+  if (emotion === 'sad') return (
+    <g>
+      <path d={`M ${x1-3} ${y+2} q 3 -3 6 0`} {...s}/>
+      <path d={`M ${x2-3} ${y+2} q 3 -3 6 0`} {...s}/>
+      <path d={`M ${x2+1} ${y+4} q 1 4 0 6`} {...ink({stroke:'var(--t-accent)', strokeWidth:1})}/>
+    </g>
+  );
+  // hopeful — looking up
+  if (emotion === 'hopeful') return (
+    <g>
+      <circle cx={x1+1} cy={y-1.5} r={1.4} fill={STROKE}/>
+      <circle cx={x2+1} cy={y-1.5} r={1.4} fill={STROKE}/>
+    </g>
+  );
+  // silence — closed, calm horizontal lines
+  if (emotion === 'silence') return (
+    <g>
+      <path d={`M ${x1-3} ${y} h 6`} {...s}/>
+      <path d={`M ${x2-3} ${y} h 6`} {...s}/>
+    </g>
+  );
+  return null;
+}
+
+function Mouth({ emotion, cx=34, cy=40 }) {
+  const s = ink();
+  if (emotion === 'listening') return <path d={`M ${cx-3} ${cy} h 6`} {...s}/>;
+  if (emotion === 'curious')   return <path d={`M ${cx-3} ${cy-1} q 3 3 6 0`} {...s}/>;
+  if (emotion === 'moved')     return <path d={`M ${cx-3} ${cy-1} q 3 2 6 -1`} {...s}/>;
+  if (emotion === 'sad')       return <path d={`M ${cx-4} ${cy+1} q 4 -3 8 0`} {...s}/>;
+  if (emotion === 'hopeful')   return <path d={`M ${cx-3} ${cy-1} q 3 4 6 0`} {...s}/>;
+  if (emotion === 'silence')   return <path d={`M ${cx-2} ${cy} h 4`} {...ink({strokeWidth:1.2})}/>;
+  return null;
+}
+
+// ── Wren — feathered creature (documentarian)
+function Wren({ emotion = 'listening', size = 96 }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 68 68" className="anim-mascot">
+      {/* body — single brushy stroke */}
+      <path d="M 12 50 Q 8 32, 22 18 Q 38 8, 54 22 Q 60 36, 50 50 Q 48 56, 40 56 Q 22 58, 12 50 Z" {...ink({strokeWidth:1.6})}/>
+      {/* feather strokes */}
+      <path d="M 18 46 Q 26 40, 34 46" {...ink({strokeWidth:0.9})} opacity="0.55"/>
+      <path d="M 22 50 Q 30 46, 40 50" {...ink({strokeWidth:0.9})} opacity="0.5"/>
+      {/* beak */}
+      <path d="M 50 28 l 6 2 l -5 3 z" {...ink({strokeWidth:1.2})} fill="var(--t-paper)"/>
+      <Eyes emotion={emotion} x1={28} x2={42} y={28}/>
+      <Mouth emotion={emotion} cx={36} cy={38}/>
+    </svg>
+  );
+}
+
+// ── Pip — round petal-bodied creature (poet of small things)
+function Pip({ emotion = 'curious', size = 96 }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 68 68" className="anim-mascot">
+      {/* leaf-y petals around */}
+      <path d="M 14 30 q -6 -10 4 -16 q 8 -3 12 6" {...ink({strokeWidth:1})} opacity="0.55"/>
+      <path d="M 54 30 q 6 -10 -4 -16 q -8 -3 -12 6" {...ink({strokeWidth:1})} opacity="0.55"/>
+      {/* round body */}
+      <path d="M 16 36 Q 16 18, 34 16 Q 52 18, 52 36 Q 52 54, 34 56 Q 16 54, 16 36 Z" {...ink({strokeWidth:1.6})}/>
+      {/* small stem */}
+      <path d="M 34 16 q 0 -4 3 -6" {...ink({strokeWidth:1})}/>
+      <Eyes emotion={emotion} x1={28} x2={42} y={32}/>
+      <Mouth emotion={emotion} cx={34} cy={42}/>
+    </svg>
+  );
+}
+
+// ── Cassio — long-form crescent (songwriter, late-night)
+function Cassio({ emotion = 'moved', size = 96 }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 68 68" className="anim-mascot">
+      {/* crescent body */}
+      <path d="M 50 14 q -28 4 -28 22 q 0 18 28 22 q -16 -8 -16 -22 q 0 -14 16 -22 z" {...ink({strokeWidth:1.6})}/>
+      {/* small scribble — like a melody */}
+      <path d="M 16 56 q 4 -3 8 0 t 8 0" {...ink({strokeWidth:0.9})} opacity="0.5"/>
+      <Eyes emotion={emotion} x1={30} x2={42} y={32}/>
+      <Mouth emotion={emotion} cx={36} cy={42}/>
+    </svg>
+  );
+}
+
+const MASCOTS = {
+  wren:   { name: 'Wren',   guide: 'The Documentarian',     comp: Wren,   theme: 'quiet' },
+  pip:    { name: 'Pip',    guide: 'The Poet of Small Things', comp: Pip,  theme: 'warm' },
+  cassio: { name: 'Cassio', guide: 'The Songwriter',         comp: Cassio, theme: 'noir' },
+};
+
+const EMOTIONS = ['listening', 'curious', 'moved', 'sad', 'hopeful', 'silence'];
+
+function MascotView({ id = 'wren', emotion = 'listening', size = 96 }) {
+  const M = MASCOTS[id]?.comp;
+  if (!M) return null;
+  return <M emotion={emotion} size={size}/>;
+}
+
+Object.assign(window, { MASCOTS, EMOTIONS, MascotView, Wren, Pip, Cassio });

--- a/docs/design/hifi/modals.jsx
+++ b/docs/design/hifi/modals.jsx
@@ -1,0 +1,429 @@
+// Mean It hi-fi — modal dialogs (download, save, share trace, start over).
+// Letterpress treatment — postage, wax seals, deckle paper.
+
+// ─────────── shared bits ───────────
+
+function StampMark({ children, color }) {
+  return (
+    <div style={{
+      display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+      padding: '6px 14px',
+      border: `2px solid ${color || 'var(--t-accent)'}`,
+      color: color || 'var(--t-accent)',
+      fontFamily: 'var(--t-stamp)',
+      fontSize: 12,
+      letterSpacing: '0.12em',
+      textTransform: 'uppercase',
+      transform: 'rotate(-2deg)',
+      borderRadius: 1,
+      background: 'transparent',
+      animation: 'stamp-in 360ms cubic-bezier(.2,1.4,.4,1) both',
+      opacity: 0.92,
+    }}>{children}</div>
+  );
+}
+
+function CopyLine({ url }) {
+  const [copied, setCopied] = React.useState(false);
+  const onCopy = () => {
+    try { navigator.clipboard.writeText(url); } catch(e){}
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1400);
+  };
+  return (
+    <div style={{
+      display: 'flex', alignItems: 'center',
+      border: '1px dashed var(--t-ink-faint)',
+      borderRadius: 'var(--t-radius)',
+      padding: '8px 10px 8px 14px',
+      background: 'var(--t-paper-warm)',
+      gap: 10,
+    }}>
+      <span style={{
+        flex: 1, fontFamily: 'var(--t-mono)', fontSize: 12,
+        color: 'var(--t-ink-soft)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+      }}>{url}</span>
+      <button className="btn sm" onClick={onCopy}>{copied ? '✓ copied' : 'copy'}</button>
+    </div>
+  );
+}
+
+// ─────────── DOWNLOAD ───────────
+
+function DownloadDialog({ onClose, openImageCard }) {
+  const [format, setFormat] = React.useState('pdf');
+  const [includeTrace, setIncludeTrace] = React.useState(true);
+  const [stampVisible, setStampVisible] = React.useState(true);
+  const [done, setDone] = React.useState(false);
+
+  const formats = [
+    { id: 'pdf',   name: 'PDF',         sub: 'formatted artifact, print-ready', glyph: '📄' },
+    { id: 'txt',   name: 'plain text',  sub: 'just the words, no formatting',   glyph: '⌘' },
+    { id: 'image', name: 'image card',  sub: 'shareable snapshot',              glyph: '◫' },
+  ];
+
+  return (
+    <div className="scrim" onClick={onClose}>
+      <div className="dialog" style={{ maxWidth: 600 }} onClick={e => e.stopPropagation()}>
+        <button className="close" onClick={onClose}>esc · close</button>
+
+        <div className="eyebrow">step 06 · take it with you</div>
+        <h2 className="h-display tiny" style={{ marginTop: 8, marginBottom: 6 }}>Download</h2>
+        <div className="body-prose" style={{ fontSize: 16, marginBottom: 22 }}>
+          Choose how you want it on paper.
+        </div>
+
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 8, marginBottom: 22 }}>
+          {formats.map(f => (
+            <button key={f.id} onClick={() => setFormat(f.id)}
+              className={'card ' + (format === f.id ? 'selected' : 'outlined')}
+              style={{
+                display: 'grid', gridTemplateColumns: '40px 1fr auto',
+                gap: 14, alignItems: 'center', textAlign: 'left',
+                cursor: 'pointer', padding: '14px 18px', fontFamily: 'inherit', color: 'inherit',
+              }}>
+              <div style={{
+                fontFamily: 'var(--t-display)', fontSize: 26,
+                color: format === f.id ? 'var(--t-accent)' : 'var(--t-ink-soft)',
+                textAlign: 'center',
+              }}>{f.glyph}</div>
+              <div>
+                <div className="serif-italic" style={{ fontSize: 19, color: 'var(--t-ink)' }}>{f.name}</div>
+                <div className="muted" style={{ fontFamily: 'var(--t-mono)', fontSize: 10, marginTop: 2 }}>{f.sub}</div>
+              </div>
+              <div style={{ fontFamily: 'var(--t-mono)', fontSize: 10, color: 'var(--t-ink-faint)', letterSpacing: '0.14em' }}>
+                {format === f.id ? '●' : '○'}
+              </div>
+            </button>
+          ))}
+        </div>
+
+        <div className="plate deep" style={{ padding: '14px 16px', marginBottom: 22 }}>
+          <div className="eyebrow" style={{ marginBottom: 10 }}>included on the artifact</div>
+          <label style={{ display: 'flex', alignItems: 'center', gap: 10, cursor: 'pointer', marginBottom: 8 }}>
+            <input type="checkbox" checked={stampVisible} onChange={e => setStampVisible(e.target.checked)}/>
+            <span className="serif-italic" style={{ fontSize: 16, color: 'var(--t-ink)' }}>'Mean It' wordmark + 100% yours stamp</span>
+          </label>
+          <label style={{ display: 'flex', alignItems: 'center', gap: 10, cursor: 'pointer' }}>
+            <input type="checkbox" checked={includeTrace} onChange={e => setIncludeTrace(e.target.checked)}/>
+            <span className="serif-italic" style={{ fontSize: 16, color: 'var(--t-ink)' }}>provenance trace appendix · the questions + your verbatim answers</span>
+          </label>
+        </div>
+
+        {/* preview thumb */}
+        <div style={{
+          background: 'var(--t-paper-warm)',
+          border: '1px solid var(--t-ink-ghost)',
+          borderRadius: 'var(--t-radius)',
+          padding: 18,
+          marginBottom: 22,
+          position: 'relative',
+        }}>
+          <div className="eyebrow" style={{ marginBottom: 10 }}>preview · {format}</div>
+          <div style={{
+            background: 'var(--t-paper)',
+            border: '1px solid var(--t-ink-ghost)',
+            borderRadius: 'var(--t-radius)',
+            padding: '20px 24px',
+            position: 'relative',
+            fontFamily: 'var(--t-body)',
+            fontSize: 11,
+            lineHeight: 1.6,
+            color: 'var(--t-ink)',
+            minHeight: 120,
+            boxShadow: 'inset 0 1px 0 var(--t-paper-highlight), inset 0 -1px 0 var(--t-paper-shadow)',
+          }}>
+            {stampVisible && (
+              <div style={{ position: 'absolute', top: 8, right: 8, transform: 'rotate(8deg)' }}>
+                <div className="postmark" style={{ width: 50, height: 50, borderWidth: 1.5, padding: 4 }}>
+                  <div className="pm-mid" style={{ fontSize: 7 }}>100%</div>
+                </div>
+              </div>
+            )}
+            <div style={{ textAlign: 'center', fontFamily: 'var(--t-mono)', fontSize: 7, letterSpacing: '0.18em', textTransform: 'uppercase', color: 'var(--t-ink-faint)', marginBottom: 8 }}>
+              for tomas · saturday
+            </div>
+            <div style={{ textAlign: 'center', fontStyle: 'italic' }}>
+              "His hands tuned the radio dial like it was a violin string."
+            </div>
+            <div style={{ textAlign: 'center', marginTop: 4, fontStyle: 'italic' }}>
+              "The world is wide and the kitchen is small."
+            </div>
+            {includeTrace && (
+              <div style={{ marginTop: 14, paddingTop: 8, borderTop: '1px dashed var(--t-ink-ghost)', fontFamily: 'var(--t-mono)', fontSize: 7, color: 'var(--t-ink-faint)', letterSpacing: '0.1em' }}>
+                ── appendix · trace ──<br/>
+                q3 · "when you picture his hands…" → "his hands tuned the radio…"<br/>
+                q4 · "was there a phrase only he used?" → "the world is wide…"
+              </div>
+            )}
+            {stampVisible && (
+              <div style={{ textAlign: 'center', marginTop: 14, fontFamily: 'var(--t-display)', fontStyle: 'italic', fontSize: 10, color: 'var(--t-seal)' }}>
+                Mean It<span style={{ color: 'var(--t-accent)' }}>.</span>
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          <span className="muted" style={{ fontFamily: 'var(--t-mono)', fontSize: 10 }}>
+            stays on this device · nothing uploaded
+          </span>
+          <button className="btn primary" onClick={() => {
+            if (format === 'image' && openImageCard) { onClose(); openImageCard(); return; }
+            setDone(true);
+          }}>{format === 'image' ? '→ pick format & layout' : '↓ download ' + format}</button>
+        </div>
+
+        {done && (
+          <div style={{
+            position: 'absolute', inset: 0,
+            background: 'color-mix(in srgb, var(--t-paper) 96%, transparent)',
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+            flexDirection: 'column', gap: 18,
+            animation: 'fadein 240ms ease',
+          }}>
+            <StampMark color="var(--t-verified)">delivered</StampMark>
+            <div className="serif-italic" style={{ fontSize: 22, color: 'var(--t-ink)' }}>Saved to your downloads.</div>
+            <button className="btn sm" onClick={onClose}>close</button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ─────────── SAVE ───────────
+
+function SaveDialog({ onClose }) {
+  const [title, setTitle] = React.useState('For Tomas · Saturday');
+  const [saved, setSaved] = React.useState(false);
+  const url = 'meanit.app/letter/tomas-' + (Math.random().toString(36).slice(2, 7));
+
+  return (
+    <div className="scrim" onClick={onClose}>
+      <div className="dialog" onClick={e => e.stopPropagation()}>
+        <button className="close" onClick={onClose}>esc · close</button>
+
+        <div className="eyebrow">save · personal</div>
+        <h2 className="h-display tiny" style={{ marginTop: 8, marginBottom: 6 }}>Keep this letter.</h2>
+        <div className="body-prose" style={{ fontSize: 16, marginBottom: 24 }}>
+          Saved to your library — and reachable by anyone you share the link with.
+        </div>
+
+        {!saved && (
+          <>
+            <div className="eyebrow" style={{ marginBottom: 6 }}>title</div>
+            <input className="input-stroke" value={title} onChange={e => setTitle(e.target.value)} style={{ marginBottom: 22, fontSize: 22 }}/>
+
+            <div className="plate" style={{ padding: '14px 16px', marginBottom: 22 }}>
+              <div style={{ display: 'flex', justifyContent: 'space-between', gap: 14, fontFamily: 'var(--t-mono)', fontSize: 11, color: 'var(--t-ink-soft)' }}>
+                <span>guide · the documentarian</span>
+                <span>theme · quiet</span>
+              </div>
+              <div style={{ display: 'flex', justifyContent: 'space-between', gap: 14, fontFamily: 'var(--t-mono)', fontSize: 11, color: 'var(--t-ink-soft)', marginTop: 6 }}>
+                <span>6 verified lines</span>
+                <span>5 questions answered</span>
+              </div>
+            </div>
+
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 8, marginBottom: 22 }}>
+              <label style={{ display: 'flex', alignItems: 'center', gap: 10, cursor: 'pointer' }}>
+                <input type="radio" name="vis" defaultChecked/>
+                <span className="serif-italic" style={{ fontSize: 16, color: 'var(--t-ink)' }}>private · only you can read it</span>
+              </label>
+              <label style={{ display: 'flex', alignItems: 'center', gap: 10, cursor: 'pointer' }}>
+                <input type="radio" name="vis"/>
+                <span className="serif-italic" style={{ fontSize: 16, color: 'var(--t-ink)' }}>unlisted · anyone with the link can read</span>
+              </label>
+            </div>
+
+            <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+              <button className="btn ghost sm" onClick={onClose}>not now</button>
+              <button className="btn primary" onClick={() => setSaved(true)}>♡ save to library</button>
+            </div>
+          </>
+        )}
+
+        {saved && (
+          <div style={{ animation: 'fadein 360ms ease' }}>
+            <div style={{ display: 'flex', justifyContent: 'center', marginBottom: 24 }}>
+              <StampMark color="var(--t-verified)">saved · {new Date().toLocaleDateString(undefined, { day: 'numeric', month: 'short' })}</StampMark>
+            </div>
+            <div className="serif-italic" style={{ fontSize: 24, color: 'var(--t-ink)', textAlign: 'center', marginBottom: 6 }}>
+              {title}
+            </div>
+            <div className="muted" style={{ fontFamily: 'var(--t-mono)', fontSize: 10, textAlign: 'center', letterSpacing: '0.14em', marginBottom: 22 }}>
+              kept · readable by link
+            </div>
+
+            <div className="eyebrow" style={{ marginBottom: 8 }}>your share-back link</div>
+            <CopyLine url={url}/>
+
+            <div className="divider-flourish"><span className="ornament-glyph">·</span></div>
+
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+              <button className="btn ghost sm">view library</button>
+              <button className="btn sm" onClick={onClose}>back to letter</button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ─────────── SHARE TRACE ───────────
+
+function ShareDialog({ onClose }) {
+  const [audience, setAudience] = React.useState('public');
+  const [step, setStep] = React.useState('compose'); // compose | shared
+  const url = 'meanit.app/share/tomas-r3-trace';
+
+  const audiences = [
+    { id: 'recipient', name: 'just the recipient', sub: 'they read the letter, hover any line for the trace' },
+    { id: 'public',    name: 'public · social',    sub: 'artifact + ‘every word verified yours’ badge' },
+    { id: 'audit',     name: 'skeptics · audit',   sub: 'full provenance · every Q + A + match type' },
+  ];
+
+  return (
+    <div className="scrim" onClick={onClose}>
+      <div className="dialog" style={{ maxWidth: 620 }} onClick={e => e.stopPropagation()}>
+        <button className="close" onClick={onClose}>esc · close</button>
+
+        <div className="eyebrow accent">share · the trace stays attached</div>
+        <h2 className="h-display tiny" style={{ marginTop: 8, marginBottom: 6 }}>Send the proof,<br/>not just the words.</h2>
+        <div className="body-prose" style={{ fontSize: 16, marginBottom: 22 }}>
+          Pick who you're sharing with. The trace becomes the receipt.
+        </div>
+
+        {step === 'compose' && (
+          <>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 8, marginBottom: 22 }}>
+              {audiences.map(a => (
+                <button key={a.id} onClick={() => setAudience(a.id)}
+                  className={'card ' + (audience === a.id ? 'selected' : 'outlined')}
+                  style={{
+                    textAlign: 'left', cursor: 'pointer',
+                    padding: '14px 18px', fontFamily: 'inherit', color: 'inherit',
+                  }}>
+                  <div className="serif-italic" style={{ fontSize: 19, color: 'var(--t-ink)' }}>{a.name}</div>
+                  <div className="muted" style={{ fontFamily: 'var(--t-mono)', fontSize: 10, marginTop: 4 }}>{a.sub}</div>
+                </button>
+              ))}
+            </div>
+
+            {/* preview card per audience */}
+            <div className="plate deep" style={{ padding: 18, marginBottom: 22, position: 'relative' }}>
+              <div className="eyebrow" style={{ marginBottom: 10 }}>recipients see</div>
+              {audience === 'recipient' && (
+                <div style={{ fontFamily: 'var(--t-body)', fontSize: 14, color: 'var(--t-ink)', textAlign: 'center', padding: 8 }}>
+                  <div style={{ fontStyle: 'italic', marginBottom: 6 }}>"His hands tuned the radio dial like it was a violin string."</div>
+                  <div className="muted" style={{ fontFamily: 'var(--t-mono)', fontSize: 9, letterSpacing: '0.14em' }}>
+                    hover any line · see the question that prompted it
+                  </div>
+                </div>
+              )}
+              {audience === 'public' && (
+                <div style={{ display: 'grid', gridTemplateColumns: '1fr auto', gap: 14, alignItems: 'center' }}>
+                  <div style={{ fontFamily: 'var(--t-body)', fontSize: 14, color: 'var(--t-ink)', fontStyle: 'italic' }}>
+                    "I tune the dial the same way now. I never told him."
+                  </div>
+                  <div className="postmark" style={{ width: 64, height: 64, borderWidth: 2, padding: 4 }}>
+                    <div className="pm-top" style={{ fontSize: 6 }}>verified</div>
+                    <div className="pm-mid" style={{ fontSize: 9 }}>100%</div>
+                    <div className="pm-bot" style={{ fontSize: 6 }}>yours</div>
+                  </div>
+                </div>
+              )}
+              {audience === 'audit' && (
+                <div style={{ fontFamily: 'var(--t-mono)', fontSize: 11, color: 'var(--t-ink-soft)', lineHeight: 1.7 }}>
+                  <div>q1 · phone greeting → "Pronto, who's calling…" · <span style={{ color: 'var(--t-verified)' }}>verbatim</span></div>
+                  <div>q2 · notebook of names → "wrote down strangers' names" · <span style={{ color: 'var(--t-verified)' }}>paraphrased ✓</span></div>
+                  <div>q3 · hands → "tuned the dial like a violin string" · <span style={{ color: 'var(--t-verified)' }}>verbatim</span></div>
+                  <div>q4 · phrase → "world is wide…" · <span style={{ color: 'var(--t-verified)' }}>verbatim</span></div>
+                  <div>q5 · what you didn't say → "I tune the dial…" · <span style={{ color: 'var(--t-verified)' }}>verbatim</span></div>
+                </div>
+              )}
+            </div>
+
+            <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+              <button className="btn ghost sm" onClick={onClose}>cancel</button>
+              <button className="btn primary" onClick={() => setStep('shared')}>↗ generate share link</button>
+            </div>
+          </>
+        )}
+
+        {step === 'shared' && (
+          <div style={{ animation: 'fadein 360ms ease' }}>
+            <div style={{ display: 'flex', justifyContent: 'center', marginBottom: 22 }}>
+              <StampMark color="var(--t-verified)">link · sealed</StampMark>
+            </div>
+            <div className="serif-italic" style={{ fontSize: 22, color: 'var(--t-ink)', textAlign: 'center', marginBottom: 18 }}>
+              The trace is attached forever.
+            </div>
+
+            <div className="eyebrow" style={{ marginBottom: 8 }}>share-trace link</div>
+            <CopyLine url={url}/>
+
+            <div style={{ marginTop: 18 }}>
+              <div className="eyebrow" style={{ marginBottom: 8 }}>or send to</div>
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+                {['email', 'sms', 'twitter', 'bluesky', 'qr code'].map(c => (
+                  <button key={c} className="btn ghost sm" style={{ textTransform: 'uppercase' }}>{c}</button>
+                ))}
+              </div>
+            </div>
+
+            <div className="divider-flourish"><span className="ornament-glyph">·</span></div>
+
+            <div className="muted" style={{ fontFamily: 'var(--t-mono)', fontSize: 10, textAlign: 'center', letterSpacing: '0.14em' }}>
+              audience · {audience === 'recipient' ? 'private viewer' : audience === 'public' ? 'public + verified badge' : 'full audit log'}
+            </div>
+
+            <div style={{ display: 'flex', justifyContent: 'center', marginTop: 16 }}>
+              <button className="btn sm" onClick={onClose}>done</button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ─────────── START OVER ───────────
+
+function StartOverDialog({ onClose, confirm }) {
+  return (
+    <div className="scrim" onClick={onClose}>
+      <div className="dialog" style={{ maxWidth: 480 }} onClick={e => e.stopPropagation()}>
+        <button className="close" onClick={onClose}>esc · close</button>
+
+        <div style={{ display: 'flex', justifyContent: 'center', marginBottom: 18 }}>
+          <StampMark>begin again</StampMark>
+        </div>
+
+        <h2 className="h-display tiny" style={{ textAlign: 'center', marginBottom: 14 }}>Start a new letter?</h2>
+        <div className="body-prose" style={{ fontSize: 16, textAlign: 'center', marginBottom: 22 }}>
+          This one is safe — already saved to your library. We'll begin fresh: a new moment, a new guide, a new spine.
+        </div>
+
+        <div className="plate" style={{ padding: '14px 18px', marginBottom: 22 }}>
+          <div className="eyebrow" style={{ marginBottom: 6 }}>this letter stays</div>
+          <div className="serif-italic" style={{ fontSize: 17, color: 'var(--t-ink)' }}>For Tomas · Saturday</div>
+          <div className="muted" style={{ fontFamily: 'var(--t-mono)', fontSize: 10, marginTop: 4 }}>kept in library · share-link active</div>
+        </div>
+
+        <div style={{ display: 'flex', justifyContent: 'space-between', gap: 10 }}>
+          <button className="btn ghost sm" onClick={onClose}>not yet</button>
+          <button className="btn primary" onClick={confirm}>begin again →</button>
+        </div>
+
+        <div className="muted" style={{ fontFamily: 'var(--t-mono)', fontSize: 9, textAlign: 'center', letterSpacing: '0.14em', marginTop: 18, textTransform: 'uppercase' }}>
+          you can write a different letter for the same person, too
+        </div>
+      </div>
+    </div>
+  );
+}
+
+Object.assign(window, { DownloadDialog, SaveDialog, ShareDialog, StartOverDialog, StampMark, CopyLine });

--- a/docs/design/hifi/reel.jsx
+++ b/docs/design/hifi/reel.jsx
@@ -1,0 +1,862 @@
+// Mean It hi-fi — Reel composer flow + Image card export.
+// 5 reel screens: photos → voice → storyboard → render → result.
+// + ImageCardDialog (format + layout picker).
+
+// ─────────── shared: photo placeholder visual ───────────
+function PhotoTile({ idx, src, descr, onRemove }) {
+  return (
+    <div className="plate" style={{
+      position: 'relative', padding: 0, overflow: 'hidden',
+      aspectRatio: '1', background: 'var(--t-paper-warm)',
+    }}>
+      {/* fake photo: gradient + index, like a polaroid placeholder */}
+      <div style={{
+        position: 'absolute', inset: 0,
+        background: src || `linear-gradient(${135 + idx * 30}deg, color-mix(in srgb, var(--t-accent) 30%, var(--t-paper)), color-mix(in srgb, var(--t-ink-soft) 20%, var(--t-paper-warm)))`,
+        backgroundSize: 'cover', backgroundPosition: 'center',
+      }}/>
+      {/* corner: index */}
+      <div style={{
+        position: 'absolute', top: 6, left: 6,
+        fontFamily: 'var(--t-stamp)', fontSize: 11, color: 'var(--t-paper)',
+        background: 'rgba(0,0,0,0.5)', padding: '2px 6px', borderRadius: 1,
+      }}>#{String(idx + 1).padStart(2,'0')}</div>
+      {onRemove && (
+        <button onClick={onRemove} style={{
+          position: 'absolute', top: 6, right: 6,
+          background: 'rgba(0,0,0,0.55)', color: 'var(--t-paper)',
+          border: 'none', borderRadius: 1, padding: '2px 7px', cursor: 'pointer',
+          fontFamily: 'var(--t-mono)', fontSize: 9, letterSpacing: '0.1em',
+        }}>×</button>
+      )}
+      {/* AI description chip */}
+      {descr && (
+        <div style={{
+          position: 'absolute', left: 0, right: 0, bottom: 0,
+          padding: '8px 10px',
+          background: 'linear-gradient(180deg, transparent, rgba(0,0,0,0.6))',
+          color: 'var(--t-paper)',
+          fontFamily: 'var(--t-body)', fontSize: 11, fontStyle: 'italic',
+          lineHeight: 1.3,
+        }}>{descr}</div>
+      )}
+    </div>
+  );
+}
+
+// ─────────── REEL FLOW ───────────
+
+const REEL_STEPS = [
+  { id: 'photos',     label: '01 · photos'     },
+  { id: 'voice',      label: '02 · voice'      },
+  { id: 'storyboard', label: '03 · storyboard' },
+  { id: 'render',     label: '04 · render'     },
+  { id: 'result',     label: '05 · result'     },
+];
+
+function ReelFlow({ onClose, theme }) {
+  const [step, setStep] = React.useState('photos');
+  const [photos, setPhotos] = React.useState([
+    { id: 1, descr: 'a man bent over a small radio · evening light · kitchen' },
+    { id: 2, descr: 'kitchen table · a cup of espresso, half full' },
+    { id: 3, descr: 'a small notebook, page filled with handwriting' },
+  ]);
+  const [voice, setVoice] = React.useState({ recorded: false, duration: 38 });
+  const [shots, setShots] = React.useState([
+    { id: 's1', t: 0,    dur: 4,   line: 'Tomas kept a notebook in his coat pocket.', photo: 3 },
+    { id: 's2', t: 4,    dur: 5,   line: "He wrote down strangers' names so he could greet them next time.", photo: 3 },
+    { id: 's3', t: 9,    dur: 7,   line: 'His hands tuned the radio dial like it was a violin string.', photo: 1 },
+    { id: 's4', t: 16,   dur: 7,   line: 'He used to say: the world is wide and the kitchen is small.', photo: 2 },
+    { id: 's5', t: 23,   dur: 6,   line: 'I tune the dial the same way now.', photo: 1 },
+    { id: 's6', t: 29,   dur: 5,   line: 'I never told him.', photo: 1 },
+  ]);
+
+  const stepIdx = REEL_STEPS.findIndex(s => s.id === step);
+  const next = () => {
+    if (stepIdx < REEL_STEPS.length - 1) setStep(REEL_STEPS[stepIdx + 1].id);
+  };
+  const back = () => {
+    if (stepIdx > 0) setStep(REEL_STEPS[stepIdx - 1].id);
+  };
+
+  return (
+    <div className="scrim" onClick={onClose}>
+      <div className="dialog" style={{ maxWidth: 1080, width: '100%', padding: 0 }} onClick={e => e.stopPropagation()}>
+        <button className="close" onClick={onClose}>esc · close</button>
+
+        {/* reel chrome — sub-stepper */}
+        <div style={{
+          padding: '20px 36px 16px',
+          borderBottom: '1px solid var(--t-ink-ghost)',
+          background: 'var(--t-paper-warm)',
+          position: 'relative',
+        }}>
+          <div className="tape tl" style={{ left: 36 }}/>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+            <div>
+              <div className="eyebrow accent">make it move</div>
+              <div className="serif-italic" style={{ fontSize: 24, color: 'var(--t-ink)', marginTop: 2 }}>
+                A reel · for Tomas
+              </div>
+            </div>
+            <div style={{ display: 'flex', gap: 14, alignItems: 'center' }}>
+              {REEL_STEPS.map((s, i) => (
+                <button key={s.id} onClick={() => setStep(s.id)}
+                  style={{
+                    background: 'none', border: 'none', padding: 0, cursor: 'pointer',
+                    fontFamily: 'var(--t-mono)', fontSize: 10, letterSpacing: '0.14em',
+                    textTransform: 'uppercase',
+                    color: s.id === step ? 'var(--t-ink)' : i < stepIdx ? 'var(--t-ink-soft)' : 'var(--t-ink-faint)',
+                    opacity: i <= stepIdx ? 1 : 0.5,
+                    position: 'relative',
+                    paddingBottom: 2,
+                    borderBottom: s.id === step ? '1px solid var(--t-seal)' : '1px solid transparent',
+                  }}>
+                  {s.label}
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        <div style={{ padding: '32px 36px 28px' }}>
+          {step === 'photos'     && <ReelPhotos photos={photos} setPhotos={setPhotos} next={next}/>}
+          {step === 'voice'      && <ReelVoice voice={voice} setVoice={setVoice} back={back} next={next}/>}
+          {step === 'storyboard' && <ReelStoryboard shots={shots} setShots={setShots} photos={photos} back={back} next={next}/>}
+          {step === 'render'     && <ReelRender shots={shots} photos={photos} back={back} next={next} theme={theme}/>}
+          {step === 'result'     && <ReelResult onClose={onClose} regen={() => setStep('storyboard')}/>}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─────────── 01 · photos ───────────
+
+function ReelPhotos({ photos, setPhotos, next }) {
+  const [drag, setDrag] = React.useState(false);
+  const [analyzing, setAnalyzing] = React.useState(false);
+
+  const fakeAdd = () => {
+    setAnalyzing(true);
+    setTimeout(() => {
+      setPhotos(p => [...p, { id: Date.now(), descr: 'analysing · finding subject, mood, light…' }]);
+      setTimeout(() => {
+        setPhotos(p => p.map((ph, i) => i === p.length - 1
+          ? { ...ph, descr: 'a hand holding a coffee cup · warm light · interior' }
+          : ph));
+        setAnalyzing(false);
+      }, 1200);
+    }, 200);
+  };
+
+  return (
+    <div>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-end', marginBottom: 18 }}>
+        <div>
+          <div className="eyebrow">step 01 · bring in the images</div>
+          <h2 className="h-display tiny" style={{ marginTop: 6 }}>Photos for the reel.</h2>
+          <div className="body-prose" style={{ fontSize: 14, marginTop: 4 }}>
+            Drop in 3–8 photos. We'll read them for subject, light, and mood — you can rearrange later.
+          </div>
+        </div>
+        <div className="postmark" style={{ width: 78, height: 78, transform: 'rotate(4deg)', borderWidth: 2 }}>
+          <div className="pm-top" style={{ fontSize: 7 }}>processing</div>
+          <div className="pm-mid" style={{ fontSize: 11 }}>{photos.length}/8</div>
+          <div className="pm-bot" style={{ fontSize: 7 }}>photos in</div>
+        </div>
+      </div>
+
+      <div
+        onDragOver={e => { e.preventDefault(); setDrag(true); }}
+        onDragLeave={() => setDrag(false)}
+        onDrop={e => { e.preventDefault(); setDrag(false); fakeAdd(); }}
+        onClick={fakeAdd}
+        style={{
+          border: '1.5px dashed ' + (drag ? 'var(--t-accent)' : 'var(--t-ink-faint)'),
+          borderRadius: 'var(--t-radius)',
+          padding: '36px 24px',
+          textAlign: 'center',
+          background: drag ? 'var(--t-accent-soft)' : 'var(--t-paper-warm)',
+          cursor: 'pointer',
+          marginBottom: 22,
+          transition: 'all 200ms',
+        }}>
+        <div style={{ fontFamily: 'var(--t-display)', fontStyle: 'italic', fontSize: 28, color: 'var(--t-ink)', marginBottom: 4 }}>
+          drop photos here
+        </div>
+        <div className="muted" style={{ fontFamily: 'var(--t-mono)', fontSize: 10, letterSpacing: '0.16em', textTransform: 'uppercase' }}>
+          or click to browse · jpg · png · heic · up to 8 images
+        </div>
+      </div>
+
+      <div className="eyebrow" style={{ marginBottom: 10 }}>gallery · {photos.length} {photos.length === 1 ? 'photo' : 'photos'}</div>
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: 10, marginBottom: 22 }}>
+        {photos.map((p, i) => (
+          <PhotoTile key={p.id} idx={i} descr={p.descr} onRemove={() => setPhotos(arr => arr.filter(x => x.id !== p.id))}/>
+        ))}
+        {photos.length < 8 && (
+          <button onClick={fakeAdd} className="card bare" style={{
+            aspectRatio: '1', cursor: 'pointer', fontFamily: 'inherit',
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+            color: 'var(--t-ink-faint)', fontSize: 32, fontFamily: 'var(--t-display)',
+            fontStyle: 'italic',
+          }}>+</button>
+        )}
+      </div>
+
+      <div className="plate deep" style={{ padding: '12px 16px', marginBottom: 22 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+          <span className="byline-dot"/>
+          <div style={{ flex: 1, fontFamily: 'var(--t-mono)', fontSize: 11, color: 'var(--t-ink-soft)', letterSpacing: '0.1em' }}>
+            {analyzing
+              ? 'photo reader · sonnet 4.6 vision · analysing latest…'
+              : 'photo reader ready · ' + photos.length + ' descriptions captured'}
+          </div>
+          <span className="muted" style={{ fontFamily: 'var(--t-mono)', fontSize: 9, letterSpacing: '0.14em' }}>
+            descriptions never leave your session
+          </span>
+        </div>
+      </div>
+
+      <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 10 }}>
+        <button className="btn primary" onClick={next} disabled={photos.length < 1}>
+          record your voice →
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ─────────── 02 · voice ───────────
+
+function ReelVoice({ voice, setVoice, back, next }) {
+  const [recording, setRecording] = React.useState(false);
+  const [time, setTime] = React.useState(0);
+
+  React.useEffect(() => {
+    if (!recording) return;
+    const i = setInterval(() => setTime(t => t + 0.1), 100);
+    return () => clearInterval(i);
+  }, [recording]);
+
+  const start = () => { setRecording(true); setTime(0); setVoice({ recorded: false, duration: 0 }); };
+  const stop = () => { setRecording(false); setVoice({ recorded: true, duration: time }); };
+  const retake = () => { setRecording(false); setTime(0); setVoice({ recorded: false, duration: 0 }); };
+
+  // fake waveform bars
+  const bars = Array.from({ length: 60 }, (_, i) => {
+    if (recording) return Math.abs(Math.sin(time * 4 + i * 0.4)) * 0.7 + Math.random() * 0.3;
+    if (voice.recorded) return Math.abs(Math.sin(i * 0.3)) * 0.6 + 0.2;
+    return 0.06;
+  });
+
+  return (
+    <div>
+      <div className="eyebrow">step 02 · your voice carries it</div>
+      <h2 className="h-display tiny" style={{ marginTop: 6 }}>Read it out loud.</h2>
+      <div className="body-prose" style={{ fontSize: 14, marginTop: 4, marginBottom: 22, maxWidth: 580 }}>
+        Read the letter slowly. Your voice — not a synth — gives the reel its weight. We'll align captions to the timing of each line.
+      </div>
+
+      <div className="plate raised" style={{ padding: '28px 32px', marginBottom: 22, position: 'relative' }}>
+        {/* the script user reads */}
+        <div className="eyebrow" style={{ marginBottom: 12 }}>read aloud · for tomas</div>
+        <div style={{
+          fontFamily: 'var(--t-body)', fontSize: 18, lineHeight: 1.7, color: 'var(--t-ink)',
+          paddingBottom: 18, borderBottom: '1px dashed var(--t-ink-ghost)', marginBottom: 22,
+          fontStyle: 'italic',
+        }}>
+          Tomas kept a notebook in his coat pocket. He wrote down strangers' names so he could greet them next time. His hands tuned the radio dial like it was a violin string. He used to say: the world is wide and the kitchen is small. I tune the dial the same way now. I never told him.
+        </div>
+
+        {/* waveform */}
+        <div style={{
+          display: 'flex', alignItems: 'center', gap: 2, height: 72,
+          padding: '0 8px', marginBottom: 14, justifyContent: 'center',
+        }}>
+          {bars.map((h, i) => (
+            <div key={i} style={{
+              width: 3, height: `${h * 100}%`,
+              background: recording ? 'var(--t-accent)' : voice.recorded ? 'var(--t-ink)' : 'var(--t-ink-ghost)',
+              borderRadius: 1,
+              transition: 'height 80ms',
+              minHeight: 2,
+            }}/>
+          ))}
+        </div>
+
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+          <div style={{ fontFamily: 'var(--t-mono)', fontSize: 12, color: 'var(--t-ink-soft)', letterSpacing: '0.14em' }}>
+            {recording ? '● recording · ' : voice.recorded ? '✓ captured · ' : 'ready · '}
+            {(voice.recorded ? voice.duration : time).toFixed(1)}s
+          </div>
+          <div style={{ display: 'flex', gap: 8 }}>
+            {!recording && !voice.recorded && (
+              <button className="btn primary" onClick={start}>● start recording</button>
+            )}
+            {recording && (
+              <button className="btn primary" onClick={stop} style={{ background: 'var(--t-ink)', borderColor: 'var(--t-ink)' }}>■ stop</button>
+            )}
+            {voice.recorded && (
+              <>
+                <button className="btn ghost sm" onClick={retake}>↺ retake</button>
+                <button className="btn sm">▶ play back</button>
+              </>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* hidden status: transcription */}
+      {voice.recorded && (
+        <div className="plate deep" style={{ padding: '12px 16px', marginBottom: 22, animation: 'fadein 320ms ease' }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+            <span className="byline-dot"/>
+            <div style={{ flex: 1, fontFamily: 'var(--t-mono)', fontSize: 11, color: 'var(--t-ink-soft)', letterSpacing: '0.1em' }}>
+              transcribing · whisper · 6 lines aligned to timestamps
+            </div>
+            <span className="muted" style={{ fontFamily: 'var(--t-mono)', fontSize: 9 }}>0:{voice.duration.toFixed(0).padStart(2,'0')}</span>
+          </div>
+        </div>
+      )}
+
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <button className="btn ghost sm" onClick={back}>← back</button>
+        <button className="btn primary" onClick={next} disabled={!voice.recorded} style={{ opacity: voice.recorded ? 1 : 0.4 }}>
+          plan the storyboard →
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ─────────── 03 · storyboard ───────────
+
+function ReelStoryboard({ shots, setShots, photos, back, next }) {
+  const move = (i, dir) => {
+    if (i + dir < 0 || i + dir >= shots.length) return;
+    const arr = [...shots]; [arr[i], arr[i + dir]] = [arr[i + dir], arr[i]];
+    setShots(arr);
+  };
+  const setPhoto = (i, photoIdx) => {
+    setShots(arr => arr.map((s, idx) => idx === i ? { ...s, photo: photoIdx + 1 } : s));
+  };
+  const totalDur = shots.reduce((n, s) => n + s.dur, 0);
+
+  return (
+    <div>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-end', marginBottom: 18 }}>
+        <div>
+          <div className="eyebrow">step 03 · the curator's plan</div>
+          <h2 className="h-display tiny" style={{ marginTop: 6 }}>The storyboard.</h2>
+          <div className="body-prose" style={{ fontSize: 14, marginTop: 4 }}>
+            Sonnet paired each line with a photo. Reorder shots, swap photos — no AI rewrites.
+          </div>
+        </div>
+        <div style={{ textAlign: 'right' }}>
+          <div className="eyebrow">total runtime</div>
+          <div className="serif-italic" style={{ fontSize: 28, color: 'var(--t-ink)' }}>{totalDur.toFixed(0)}s</div>
+        </div>
+      </div>
+
+      {/* timeline strip */}
+      <div className="plate" style={{ padding: '14px 18px', marginBottom: 18 }}>
+        <div className="eyebrow" style={{ marginBottom: 8 }}>timeline · drag-edit shot durations</div>
+        <div style={{ display: 'flex', height: 32, borderRadius: 1, overflow: 'hidden', border: '1px solid var(--t-ink-ghost)' }}>
+          {shots.map((s, i) => (
+            <div key={s.id} style={{
+              flex: s.dur, position: 'relative',
+              background: i % 2 === 0 ? 'var(--t-accent-soft)' : 'var(--t-paper-warm)',
+              borderRight: i < shots.length - 1 ? '1px solid var(--t-ink-ghost)' : 'none',
+              fontFamily: 'var(--t-mono)', fontSize: 9, letterSpacing: '0.1em',
+              color: 'var(--t-ink-soft)', textAlign: 'center',
+              display: 'flex', alignItems: 'center', justifyContent: 'center',
+            }}>{s.dur}s</div>
+          ))}
+        </div>
+      </div>
+
+      {/* shot rows */}
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 10, marginBottom: 22 }}>
+        {shots.map((s, i) => (
+          <div key={s.id} className="card outlined" style={{
+            display: 'grid',
+            gridTemplateColumns: '38px 80px 1fr auto',
+            gap: 14, alignItems: 'center',
+            padding: '12px 16px',
+          }}>
+            {/* shot number */}
+            <div style={{
+              fontFamily: 'var(--t-stamp)', fontSize: 14,
+              color: 'var(--t-accent)', textAlign: 'center',
+            }}>0{i + 1}</div>
+
+            {/* photo thumbnail */}
+            <div style={{
+              aspectRatio: '9/16', borderRadius: 1,
+              background: `linear-gradient(${135 + s.photo * 30}deg, color-mix(in srgb, var(--t-accent) 30%, var(--t-paper)), color-mix(in srgb, var(--t-ink-soft) 20%, var(--t-paper-warm)))`,
+              border: '1px solid var(--t-ink-ghost)',
+              position: 'relative',
+            }}>
+              <div style={{
+                position: 'absolute', bottom: 2, right: 2,
+                fontFamily: 'var(--t-stamp)', fontSize: 9, color: 'var(--t-paper)',
+                background: 'rgba(0,0,0,0.55)', padding: '1px 4px', borderRadius: 1,
+              }}>#{String(s.photo).padStart(2,'0')}</div>
+            </div>
+
+            {/* line + timestamp */}
+            <div>
+              <div className="muted" style={{ fontFamily: 'var(--t-mono)', fontSize: 9, letterSpacing: '0.14em', marginBottom: 4, textTransform: 'uppercase' }}>
+                {s.t.toFixed(1)}s → {(s.t + s.dur).toFixed(1)}s · {s.dur}s
+              </div>
+              <div className="serif-italic" style={{ fontSize: 16, color: 'var(--t-ink)', fontStyle: 'italic', lineHeight: 1.4 }}>
+                "{s.line}"
+              </div>
+            </div>
+
+            {/* controls */}
+            <div style={{ display: 'flex', gap: 4 }}>
+              <button className="btn ghost sm" style={{ padding: '4px 8px' }} onClick={() => move(i, -1)} disabled={i === 0}>↑</button>
+              <button className="btn ghost sm" style={{ padding: '4px 8px' }} onClick={() => move(i, 1)} disabled={i === shots.length - 1}>↓</button>
+              <select
+                value={s.photo - 1}
+                onChange={e => setPhoto(i, parseInt(e.target.value))}
+                style={{
+                  fontFamily: 'var(--t-mono)', fontSize: 10, padding: '4px 6px',
+                  background: 'var(--t-paper)', border: '1px solid var(--t-ink-ghost)',
+                  color: 'var(--t-ink)', borderRadius: 1,
+                }}>
+                {photos.map((_, j) => <option key={j} value={j}>swap · #{String(j + 1).padStart(2,'0')}</option>)}
+              </select>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+        <button className="btn ghost sm" onClick={back}>← back</button>
+        <button className="btn primary" onClick={next}>render preview →</button>
+      </div>
+    </div>
+  );
+}
+
+// ─────────── 04 · render preview ───────────
+
+function ReelRender({ shots, photos, back, next, theme }) {
+  const [shotIdx, setShotIdx] = React.useState(0);
+  const [playing, setPlaying] = React.useState(true);
+  const [progress, setProgress] = React.useState(0); // 0..1 within current shot
+  const totalDur = shots.reduce((n, s) => n + s.dur, 0);
+
+  React.useEffect(() => {
+    if (!playing) return;
+    const cur = shots[shotIdx];
+    const i = setInterval(() => {
+      setProgress(p => {
+        if (p >= 1) {
+          setShotIdx(idx => (idx + 1) % shots.length);
+          return 0;
+        }
+        return p + 0.1 / cur.dur;
+      });
+    }, 100);
+    return () => clearInterval(i);
+  }, [playing, shotIdx, shots]);
+
+  const cur = shots[shotIdx];
+  const elapsedTime = shots.slice(0, shotIdx).reduce((n, s) => n + s.dur, 0) + cur.dur * progress;
+
+  return (
+    <div>
+      <div className="eyebrow">step 04 · live preview</div>
+      <h2 className="h-display tiny" style={{ marginTop: 6, marginBottom: 18 }}>Watch it through.</h2>
+
+      <div style={{ display: 'grid', gridTemplateColumns: '300px 1fr', gap: 36 }}>
+        {/* the 9:16 canvas */}
+        <div style={{
+          aspectRatio: '9/16',
+          width: 300,
+          background: 'var(--t-ink)',
+          borderRadius: 6,
+          position: 'relative',
+          overflow: 'hidden',
+          boxShadow: '0 18px 56px rgba(0,0,0,0.4), inset 0 0 0 1px var(--t-ink)',
+        }}>
+          {/* photo with ken burns */}
+          <div style={{
+            position: 'absolute', inset: 0,
+            background: `linear-gradient(${135 + cur.photo * 30}deg, color-mix(in srgb, var(--t-accent) 60%, var(--t-paper)), color-mix(in srgb, var(--t-ink-soft) 50%, var(--t-paper-warm)))`,
+            transform: `scale(${1.05 + progress * 0.12})`,
+            transition: 'transform 100ms linear',
+          }}/>
+          {/* darken overlay */}
+          <div style={{
+            position: 'absolute', inset: 0,
+            background: 'linear-gradient(180deg, transparent 40%, rgba(0,0,0,0.6) 100%)',
+          }}/>
+          {/* caption */}
+          <div style={{
+            position: 'absolute', left: 16, right: 16, bottom: 70,
+            fontFamily: 'var(--t-display)',
+            fontStyle: 'italic',
+            fontWeight: 600,
+            color: 'var(--t-paper)',
+            fontSize: 17,
+            lineHeight: 1.3,
+            textAlign: 'center',
+            textShadow: '0 1px 2px rgba(0,0,0,0.5)',
+            opacity: progress < 0.05 ? progress / 0.05 : progress > 0.95 ? (1 - progress) / 0.05 : 1,
+          }}>"{cur.line}"</div>
+          {/* corner postmark */}
+          <div style={{ position: 'absolute', top: 12, right: 12, transform: 'rotate(8deg)' }}>
+            <div className="postmark" style={{ width: 50, height: 50, borderWidth: 1.5, padding: 4, color: 'var(--t-paper)', borderColor: 'var(--t-paper)' }}>
+              <div className="pm-mid" style={{ fontSize: 8, color: 'var(--t-paper)' }}>100%</div>
+            </div>
+          </div>
+          {/* end-card cue at last shot */}
+          {shotIdx === shots.length - 1 && progress > 0.6 && (
+            <div style={{
+              position: 'absolute', inset: 0,
+              background: 'rgba(0,0,0,0.55)',
+              display: 'flex', flexDirection: 'column',
+              alignItems: 'center', justifyContent: 'center',
+              opacity: (progress - 0.6) / 0.4,
+            }}>
+              <div style={{ fontFamily: 'var(--t-display)', fontStyle: 'italic', fontSize: 22, color: 'var(--t-paper)' }}>
+                Mean It<span style={{ color: 'var(--t-accent)' }}>.</span>
+              </div>
+              <div style={{ fontFamily: 'var(--t-mono)', fontSize: 8, letterSpacing: '0.18em', color: 'var(--t-paper)', marginTop: 6, textTransform: 'uppercase' }}>
+                every word verified yours
+              </div>
+            </div>
+          )}
+          {/* progress bar */}
+          <div style={{ position: 'absolute', bottom: 0, left: 0, right: 0, height: 3, background: 'rgba(255,255,255,0.18)' }}>
+            <div style={{
+              height: '100%',
+              width: `${(elapsedTime / totalDur) * 100}%`,
+              background: 'var(--t-accent)',
+              transition: 'width 100ms linear',
+            }}/>
+          </div>
+        </div>
+
+        {/* status panel */}
+        <div>
+          <div className="plate deep" style={{ padding: '16px 20px', marginBottom: 16 }}>
+            <div className="eyebrow" style={{ marginBottom: 8 }}>now showing</div>
+            <div className="serif-italic" style={{ fontSize: 18, color: 'var(--t-ink)', fontStyle: 'italic', marginBottom: 6 }}>
+              "{cur.line}"
+            </div>
+            <div className="muted" style={{ fontFamily: 'var(--t-mono)', fontSize: 10, letterSpacing: '0.12em' }}>
+              shot 0{shotIdx + 1} / 0{shots.length} · {elapsedTime.toFixed(1)}s of {totalDur.toFixed(1)}s
+            </div>
+          </div>
+
+          <div style={{ display: 'flex', gap: 8, marginBottom: 22 }}>
+            <button className="btn sm" onClick={() => setPlaying(p => !p)}>{playing ? '❚❚ pause' : '▶ play'}</button>
+            <button className="btn ghost sm" onClick={() => { setShotIdx(0); setProgress(0); }}>↺ restart</button>
+            <button className="btn ghost sm" onClick={() => setShotIdx(i => (i + 1) % shots.length)}>⏵ next shot</button>
+          </div>
+
+          <div className="plate" style={{ padding: '14px 18px', marginBottom: 18 }}>
+            <div className="eyebrow" style={{ marginBottom: 8 }}>render specs</div>
+            <div style={{ fontFamily: 'var(--t-mono)', fontSize: 11, color: 'var(--t-ink-soft)', lineHeight: 1.7 }}>
+              <div>format · 1080 × 1920 · 9:16 · 30 fps</div>
+              <div>codec · h.264 mp4 · ~6 mbps</div>
+              <div>theme · {theme} · captions in {theme} palette</div>
+              <div>motion · ken burns + caption fades</div>
+              <div>audio · your voice · {totalDur.toFixed(0)}s</div>
+            </div>
+          </div>
+
+          <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+            <button className="btn ghost sm" onClick={back}>← edit storyboard</button>
+            <button className="btn primary" onClick={next}>render reel →</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─────────── 05 · result ───────────
+
+function ReelResult({ onClose, regen }) {
+  const [showShare, setShowShare] = React.useState(false);
+
+  return (
+    <div style={{ animation: 'fadein 360ms ease' }}>
+      <div style={{ display: 'flex', justifyContent: 'center', marginBottom: 22 }}>
+        <StampMark color="var(--t-verified)">rendered · ready</StampMark>
+      </div>
+
+      <div style={{ display: 'grid', gridTemplateColumns: '300px 1fr', gap: 36, alignItems: 'center' }}>
+        {/* finished reel poster */}
+        <div style={{
+          aspectRatio: '9/16', width: 300,
+          background: 'var(--t-ink)',
+          borderRadius: 6, overflow: 'hidden', position: 'relative',
+          boxShadow: '0 18px 56px rgba(0,0,0,0.4)',
+        }}>
+          <div style={{ position: 'absolute', inset: 0,
+            background: 'linear-gradient(155deg, color-mix(in srgb, var(--t-accent) 60%, var(--t-paper)), color-mix(in srgb, var(--t-ink-soft) 50%, var(--t-paper-warm)))',
+          }}/>
+          <div style={{ position: 'absolute', inset: 0, background: 'linear-gradient(180deg, transparent 50%, rgba(0,0,0,0.65) 100%)' }}/>
+          <div style={{
+            position: 'absolute', left: 20, right: 20, bottom: 90,
+            fontFamily: 'var(--t-display)', fontStyle: 'italic', fontWeight: 600,
+            color: 'var(--t-paper)', fontSize: 22, lineHeight: 1.25, textAlign: 'center',
+            textShadow: '0 2px 4px rgba(0,0,0,0.5)',
+          }}>"His hands tuned the radio dial like it was a violin string."</div>
+          <div style={{
+            position: 'absolute', bottom: 28, left: 0, right: 0, textAlign: 'center',
+            fontFamily: 'var(--t-display)', fontStyle: 'italic', fontSize: 14, color: 'var(--t-paper)',
+          }}>Mean It<span style={{ color: 'var(--t-accent)' }}>.</span></div>
+          <div style={{ position: 'absolute', top: 12, right: 12, transform: 'rotate(8deg)' }}>
+            <div className="postmark" style={{ width: 56, height: 56, borderWidth: 2, padding: 4, color: 'var(--t-paper)', borderColor: 'var(--t-paper)' }}>
+              <div className="pm-top" style={{ fontSize: 6, color: 'var(--t-paper)' }}>verified</div>
+              <div className="pm-mid" style={{ fontSize: 9, color: 'var(--t-paper)' }}>100%</div>
+              <div className="pm-bot" style={{ fontSize: 6, color: 'var(--t-paper)' }}>yours</div>
+            </div>
+          </div>
+          {/* play badge */}
+          <div style={{
+            position: 'absolute', top: '50%', left: '50%', transform: 'translate(-50%, -50%)',
+            width: 72, height: 72, borderRadius: '50%',
+            background: 'rgba(255,255,255,0.18)', backdropFilter: 'blur(6px)',
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+            fontSize: 24, color: 'var(--t-paper)',
+          }}>▶</div>
+        </div>
+
+        <div>
+          <div className="eyebrow">your reel · for tomas</div>
+          <h2 className="h-display tiny" style={{ marginTop: 6, marginBottom: 12 }}>It's ready.</h2>
+          <div className="body-prose" style={{ fontSize: 15, marginBottom: 22 }}>
+            38 seconds · 1080×1920 · your voice · six lines, all yours. Trace badge on the end card.
+          </div>
+
+          <div className="plate" style={{ padding: '14px 18px', marginBottom: 18 }}>
+            <div style={{ display: 'flex', justifyContent: 'space-between', fontFamily: 'var(--t-mono)', fontSize: 11, color: 'var(--t-ink-soft)' }}>
+              <span>file · for-tomas.mp4</span>
+              <span>5.4 MB</span>
+            </div>
+          </div>
+
+          <div className="eyebrow" style={{ marginBottom: 8 }}>save it</div>
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, marginBottom: 18 }}>
+            <button className="btn primary">↓ download mp4</button>
+            <button className="btn sm" onClick={() => setShowShare(s => !s)}>↗ share</button>
+            <button className="btn ghost sm" onClick={regen}>↺ re-render</button>
+          </div>
+
+          {showShare && (
+            <div className="plate deep" style={{ padding: '14px 16px', animation: 'fadein 240ms ease' }}>
+              <div className="eyebrow" style={{ marginBottom: 8 }}>send direct to</div>
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+                {['tiktok', 'instagram reels', 'twitter / X', 'bluesky', 'youtube short', 'qr code'].map(c => (
+                  <button key={c} className="btn ghost sm" style={{ textTransform: 'uppercase' }}>{c}</button>
+                ))}
+              </div>
+              <div className="muted" style={{ fontFamily: 'var(--t-mono)', fontSize: 9, marginTop: 10, letterSpacing: '0.14em', textTransform: 'uppercase' }}>
+                trace link is appended to the caption · receivers can verify
+              </div>
+            </div>
+          )}
+
+          <div className="divider-flourish"><span className="ornament-glyph">·</span></div>
+
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+            <span className="muted" style={{ fontFamily: 'var(--t-mono)', fontSize: 10 }}>
+              the artifact stays in your library
+            </span>
+            <button className="btn sm" onClick={onClose}>back to letter</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─────────── IMAGE CARD DIALOG (full format + layout picker) ───────────
+
+function ImageCardDialog({ onClose }) {
+  const [format, setFormat] = React.useState('1x1');
+  const [layout, setLayout] = React.useState('hero');
+  const [done, setDone] = React.useState(false);
+
+  const formats = [
+    { id: '1x1',    name: '1 : 1',   sub: 'instagram feed',          ratio: 1 },
+    { id: '4x5',    name: '4 : 5',   sub: 'instagram portrait',      ratio: 4/5 },
+    { id: '9x16',   name: '9 : 16',  sub: 'stories · tiktok',        ratio: 9/16 },
+    { id: '16x9',   name: '16 : 9',  sub: 'twitter · linkedin',      ratio: 16/9 },
+    { id: 'letter', name: 'letter',  sub: 'the artifact, photographed', ratio: 8.5/11 },
+  ];
+
+  const layouts = [
+    { id: 'paper',    name: 'letter on paper', sub: 'verbatim text · postmark' },
+    { id: 'hero',     name: 'single hero line', sub: 'one line · big type' },
+    { id: 'photo',    name: 'photo + caption', sub: 'your image · line overlaid' },
+    { id: 'carousel', name: 'carousel',        sub: 'multiple slides · trace' },
+  ];
+
+  // figure out preview frame size while keeping ratio
+  const f = formats.find(x => x.id === format);
+  const prevW = f.ratio >= 1 ? 280 : 280 * f.ratio;
+  const prevH = f.ratio >= 1 ? 280 / f.ratio : 280;
+
+  const previewBg = layout === 'photo'
+    ? 'linear-gradient(155deg, color-mix(in srgb, var(--t-accent) 60%, var(--t-paper)), color-mix(in srgb, var(--t-ink-soft) 60%, var(--t-paper-warm)))'
+    : 'var(--t-paper)';
+
+  return (
+    <div className="scrim" onClick={onClose}>
+      <div className="dialog" style={{ maxWidth: 920, padding: 0 }} onClick={e => e.stopPropagation()}>
+        <button className="close" onClick={onClose}>esc · close</button>
+
+        <div style={{ padding: '32px 36px 28px' }}>
+          <div className="eyebrow accent">image card · shareable</div>
+          <h2 className="h-display tiny" style={{ marginTop: 6, marginBottom: 6 }}>Make a snapshot.</h2>
+          <div className="body-prose" style={{ fontSize: 15, marginBottom: 24 }}>
+            Pick the size, pick the layout. The trace badge lives in the corner.
+          </div>
+
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 320px', gap: 36 }}>
+            {/* options */}
+            <div>
+              <div className="eyebrow" style={{ marginBottom: 10 }}>format</div>
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, marginBottom: 22 }}>
+                {formats.map(fmt => (
+                  <button key={fmt.id} onClick={() => setFormat(fmt.id)}
+                    className={'card ' + (format === fmt.id ? 'selected' : 'outlined')}
+                    style={{
+                      cursor: 'pointer', padding: '10px 14px', minWidth: 90,
+                      fontFamily: 'inherit', color: 'inherit', textAlign: 'center',
+                    }}>
+                    <div className="serif-italic" style={{ fontSize: 17, color: 'var(--t-ink)' }}>{fmt.name}</div>
+                    <div className="muted" style={{ fontFamily: 'var(--t-mono)', fontSize: 9, marginTop: 2, letterSpacing: '0.12em' }}>{fmt.sub}</div>
+                  </button>
+                ))}
+              </div>
+
+              <div className="eyebrow" style={{ marginBottom: 10 }}>layout</div>
+              <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8, marginBottom: 22 }}>
+                {layouts.map(lay => (
+                  <button key={lay.id} onClick={() => setLayout(lay.id)}
+                    className={'card ' + (layout === lay.id ? 'selected' : 'outlined')}
+                    style={{
+                      cursor: 'pointer', padding: '12px 14px', textAlign: 'left',
+                      fontFamily: 'inherit', color: 'inherit',
+                    }}>
+                    <div className="serif-italic" style={{ fontSize: 16, color: 'var(--t-ink)' }}>{lay.name}</div>
+                    <div className="muted" style={{ fontFamily: 'var(--t-mono)', fontSize: 9, marginTop: 2, letterSpacing: '0.12em' }}>{lay.sub}</div>
+                  </button>
+                ))}
+              </div>
+
+              <div className="plate deep" style={{ padding: '12px 16px', fontFamily: 'var(--t-mono)', fontSize: 11, color: 'var(--t-ink-soft)' }}>
+                output · {format === '1x1' ? '1080 × 1080' : format === '4x5' ? '1080 × 1350' : format === '9x16' ? '1080 × 1920' : format === '16x9' ? '1920 × 1080' : '2550 × 3300'} px · png
+              </div>
+            </div>
+
+            {/* preview */}
+            <div>
+              <div className="eyebrow" style={{ marginBottom: 10 }}>preview</div>
+              <div style={{
+                width: 300, height: 320,
+                display: 'flex', alignItems: 'center', justifyContent: 'center',
+                background: 'var(--t-paper-warm)', borderRadius: 'var(--t-radius)',
+                border: '1px dashed var(--t-ink-faint)',
+              }}>
+                <div style={{
+                  width: prevW, height: prevH,
+                  background: previewBg,
+                  borderRadius: layout === 'paper' ? 1 : 4,
+                  position: 'relative', overflow: 'hidden',
+                  boxShadow: '0 8px 24px var(--t-paper-shadow), inset 0 1px 0 var(--t-paper-highlight)',
+                  border: layout === 'paper' ? '1px solid var(--t-ink-ghost)' : 'none',
+                  fontFamily: 'var(--t-body)', color: layout === 'photo' ? 'var(--t-paper)' : 'var(--t-ink)',
+                }}>
+                  {/* postmark — always present */}
+                  <div style={{ position: 'absolute', top: 6, right: 6, transform: 'rotate(8deg)' }}>
+                    <div className="postmark" style={{
+                      width: 38, height: 38, borderWidth: 1.2, padding: 2,
+                      color: layout === 'photo' ? 'var(--t-paper)' : 'var(--t-accent)',
+                      borderColor: layout === 'photo' ? 'var(--t-paper)' : 'var(--t-accent)',
+                    }}>
+                      <div className="pm-mid" style={{ fontSize: 6, color: 'inherit' }}>100%</div>
+                    </div>
+                  </div>
+
+                  {/* layouts */}
+                  {layout === 'paper' && (
+                    <div style={{ padding: 14, fontSize: 9, lineHeight: 1.55, fontStyle: 'italic', textAlign: 'center', height: '100%', display: 'flex', flexDirection: 'column', justifyContent: 'center' }}>
+                      <div style={{ fontFamily: 'var(--t-mono)', fontStyle: 'normal', fontSize: 6, letterSpacing: '0.18em', textTransform: 'uppercase', color: 'var(--t-ink-faint)', marginBottom: 6 }}>for tomas</div>
+                      <div>"His hands tuned the radio dial like it was a violin string."</div>
+                      <div style={{ marginTop: 8 }}>"The world is wide and the kitchen is small."</div>
+                      <div style={{ marginTop: 14, fontFamily: 'var(--t-display)', fontStyle: 'italic', fontSize: 9, color: 'var(--t-seal)' }}>Mean It<span style={{ color: 'var(--t-accent)' }}>.</span></div>
+                    </div>
+                  )}
+                  {layout === 'hero' && (
+                    <div style={{ padding: 18, height: '100%', display: 'flex', flexDirection: 'column', justifyContent: 'center', textAlign: 'center' }}>
+                      <div style={{ fontFamily: 'var(--t-display)', fontStyle: 'italic', fontSize: 18, lineHeight: 1.15, color: 'var(--t-ink)' }}>
+                        "the world is wide and the kitchen is small."
+                      </div>
+                      <div style={{ fontFamily: 'var(--t-mono)', fontSize: 7, letterSpacing: '0.22em', color: 'var(--t-ink-faint)', marginTop: 12, textTransform: 'uppercase' }}>
+                        — for tomas
+                      </div>
+                    </div>
+                  )}
+                  {layout === 'photo' && (
+                    <>
+                      <div style={{ position: 'absolute', inset: 0, background: 'linear-gradient(180deg, transparent 30%, rgba(0,0,0,0.6))' }}/>
+                      <div style={{ position: 'absolute', left: 12, right: 12, bottom: 14, textAlign: 'center', fontFamily: 'var(--t-display)', fontStyle: 'italic', fontSize: 13, color: 'var(--t-paper)', textShadow: '0 1px 2px rgba(0,0,0,0.5)' }}>
+                        "I tune the dial the same way now."
+                      </div>
+                    </>
+                  )}
+                  {layout === 'carousel' && (
+                    <div style={{ padding: 14, height: '100%', display: 'flex', flexDirection: 'column', justifyContent: 'space-between' }}>
+                      <div className="eyebrow" style={{ fontSize: 6 }}>1 / 4</div>
+                      <div style={{ fontFamily: 'var(--t-display)', fontStyle: 'italic', fontSize: 13, lineHeight: 1.2, color: 'var(--t-ink)' }}>
+                        "Tomas kept a notebook in his coat pocket."
+                      </div>
+                      <div style={{ display: 'flex', gap: 3, justifyContent: 'center' }}>
+                        {[0,1,2,3].map(i => <div key={i} style={{ width: 5, height: 5, borderRadius: '50%', background: i === 0 ? 'var(--t-accent)' : 'var(--t-ink-ghost)' }}/>)}
+                      </div>
+                    </div>
+                  )}
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div className="divider-flourish"><span className="ornament-glyph">·</span></div>
+
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+            <span className="muted" style={{ fontFamily: 'var(--t-mono)', fontSize: 10 }}>rendered locally · trace badge always on</span>
+            <button className="btn primary" onClick={() => setDone(true)}>↓ download {format} png</button>
+          </div>
+
+          {done && (
+            <div style={{
+              position: 'absolute', inset: 0,
+              background: 'color-mix(in srgb, var(--t-paper) 96%, transparent)',
+              display: 'flex', alignItems: 'center', justifyContent: 'center',
+              flexDirection: 'column', gap: 16, animation: 'fadein 240ms ease',
+            }}>
+              <StampMark color="var(--t-verified)">delivered</StampMark>
+              <button className="btn sm" onClick={onClose}>close</button>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+Object.assign(window, { ReelFlow, ImageCardDialog, PhotoTile });

--- a/docs/design/hifi/screens-1.jsx
+++ b/docs/design/hifi/screens-1.jsx
@@ -1,0 +1,310 @@
+// Mean It hi-fi — eulogy demo data + screen components.
+
+const SCRIPT = {
+  recipient: 'my grandfather, Tomas',
+  occasion: 'eulogy',
+  form: 'a short letter — read aloud',
+  guide: 'documentarian',
+  mascot: 'wren',
+  theme: 'quiet',
+
+  interview: [
+    { q: "What did he always say when he answered the phone?",
+      a: "He'd say 'Pronto, who's calling my house?' — like he was offended you'd dare. He wasn't.",
+      mood: 'curious' },
+    { q: "What's a thing he did that nobody else would have done?",
+      a: "He kept a notebook in his coat pocket. Wrote down strangers' names on the bus so he could greet them next time.",
+      mood: 'moved' },
+    { q: "When you picture his hands — what are they doing?",
+      a: "Fixing the radio. Always the same radio. Tuning the dial like it was a violin string.",
+      mood: 'listening' },
+    { q: "Was there a phrase only he used?",
+      a: "'The world is wide and the kitchen is small.' He'd say it before any meal that took effort.",
+      mood: 'moved' },
+    { q: "What didn't you get to say?",
+      a: "That I learned the radio thing. I tune the dial the same way now. I never told him.",
+      mood: 'sad' },
+  ],
+
+  spineCandidates: [
+    { t: "tuning the dial like it was a violin string", from: "q3 · his hands", picked: true },
+    { t: "the world is wide and the kitchen is small", from: "q4 · his phrase" },
+    { t: "I tune the dial the same way now", from: "q5 · what you didn't say" },
+  ],
+
+  structure: [
+    { label: 'memory', sub: 'the radio, his hands' },
+    { label: 'phrase', sub: '"world is wide…"' },
+    { label: 'inheritance', sub: 'the dial · the silence · what wasn\'t said' },
+  ],
+
+  draft: [
+    { text: "Tomas kept a notebook in his coat pocket.", verified: true, src: 'q2' },
+    { text: "He wrote down strangers' names so he could greet them next time.", verified: true, src: 'q2' },
+    { text: "His hands tuned the radio dial like it was a violin string.", verified: true, src: 'q3' },
+    { text: "He used to say: the world is wide and the kitchen is small.", verified: true, src: 'q4' },
+    { text: "He was forever in our hearts.", verified: false, src: null, flag: 'cliche' },
+    { text: "I tune the dial the same way now.", verified: true, src: 'q5' },
+    { text: "I never told him.", verified: true, src: 'q5' },
+  ],
+};
+
+// ─────────── PICK THE MOMENT (B+C hybrid: feeling cards → conversational parse) ───────────
+
+function PickMoment({ go }) {
+  const [feeling, setFeeling] = React.useState(null);
+  const [text, setText] = React.useState('');
+
+  const feelings = [
+    { id: 'goodbye',     h: 'a goodbye',     s: 'eulogy · final letter' },
+    { id: 'celebration', h: 'a celebration', s: 'birthday · wedding'    },
+    { id: 'thanks',      h: 'a thank you',   s: 'gratitude · just because' },
+    { id: 'apology',     h: 'an apology',    s: 'making it right'       },
+    { id: 'love',        h: 'a love note',   s: 'partner · friend'      },
+    { id: 'else',        h: 'something else',s: 'tell me more'          },
+  ];
+
+  React.useEffect(() => {
+    if (feeling === 'goodbye') {
+      setText("My grandfather, Tomas. He passed last month. The service is Saturday. I want to say something true.");
+    }
+  }, [feeling]);
+
+  return (
+    <div className="stage" style={{ paddingTop: 56 }}>
+      <div className="eyebrow">a moment that matters</div>
+      <h1 className="h-display" style={{ marginTop: 8, marginBottom: 18 }}>
+        What kind of moment<br/>is this?
+      </h1>
+      <div className="body-prose" style={{ maxWidth: 540, marginBottom: 32 }}>
+        Pick by feeling. We'll figure out the form together.
+      </div>
+
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 14 }}>
+        {feelings.map(f => (
+          <button
+            key={f.id}
+            onClick={() => setFeeling(f.id)}
+            className={'card ' + (feeling === f.id ? 'selected' : feeling ? 'bare' : 'outlined')}
+            style={{
+              textAlign: 'left', cursor: 'pointer', minHeight: 120,
+              padding: '20px 22px',
+              fontFamily: 'inherit', color: 'inherit',
+              transition: 'all 300ms',
+            }}
+          >
+            <div className="serif-italic" style={{ fontSize: 26, lineHeight: 1.1, color: 'var(--t-ink)' }}>{f.h}</div>
+            <div className="eyebrow" style={{ marginTop: 8 }}>{f.s}</div>
+          </button>
+        ))}
+      </div>
+
+      {feeling && (
+        <div style={{ marginTop: 40 }}>
+          <div className="eyebrow">tell me what's going on</div>
+          <textarea
+            className="textarea-prose"
+            style={{ marginTop: 12, fontSize: 19 }}
+            rows={4}
+            value={text}
+            onChange={e => setText(e.target.value)}
+            placeholder="who · the occasion · anything specific you want to say…"
+          />
+          {text.length > 30 && (
+            <div style={{ marginTop: 22, animation: 'fadein 600ms ease' }}>
+              <div className="eyebrow">i heard…</div>
+              <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', marginTop: 10 }}>
+                <span className="tag on">recipient · grandfather, Tomas</span>
+                <span className="tag on">occasion · eulogy</span>
+                <span className="tag on">when · Saturday</span>
+                <span className="tag">tone · still listening</span>
+              </div>
+              <div style={{ display: 'flex', justifyContent: 'space-between', marginTop: 32, alignItems: 'center' }}>
+                <span className="muted" style={{ fontFamily: 'var(--t-mono)', fontSize: 11 }}>edit any pill — or keep going</span>
+                <button className="btn primary" onClick={go}>pick a guide →</button>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─────────── GUIDE PICKER (variant C with mascot inside) ───────────
+
+function GuidePicker({ go, openCreateGuide }) {
+  const [pick, setPick] = React.useState('wren');
+  const guides = [
+    { id: 'wren',   tag: 'memory · specifics',         desc: 'pulls for moments only one person remembers. low-key, patient.', sample: '"What did he always say when he answered the phone?"' },
+    { id: 'pip',    tag: 'sensory noticing',           desc: 'pulls for the smell, the sound, the small thing nobody else saw.', sample: '"What\'s a smell that means home?"' },
+    { id: 'cassio', tag: 'unresolved feeling',         desc: 'pulls for what didn\'t get said. comfortable with quiet.',           sample: '"What didn\'t you get to say?"' },
+  ];
+
+  return (
+    <div className="stage">
+      <div className="eyebrow">three ways of being listened to</div>
+      <h1 className="h-display smaller" style={{ marginTop: 8, marginBottom: 8 }}>Pick the kind of attention<br/>this moment needs.</h1>
+      <div className="body-prose" style={{ maxWidth: 580, marginBottom: 28 }}>
+        Each one asks differently. None of them write for you. Ever.
+      </div>
+
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
+        {guides.map(g => {
+          const M = MASCOTS[g.id];
+          return (
+            <button key={g.id} onClick={() => setPick(g.id)}
+              className={'card ' + (pick === g.id ? 'selected' : 'outlined')}
+              style={{
+                display: 'grid', gridTemplateColumns: '90px 1fr auto',
+                gap: 22, alignItems: 'center',
+                textAlign: 'left', cursor: 'pointer', padding: '18px 22px',
+                fontFamily: 'inherit', color: 'inherit',
+              }}>
+              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                <MascotView id={g.id} emotion={pick === g.id ? 'curious' : 'listening'} size={72}/>
+              </div>
+              <div>
+                <div className="serif-italic" style={{ fontSize: 24, color: 'var(--t-ink)' }}>{M.guide}</div>
+                <div className="eyebrow" style={{ marginTop: 4 }}>pulls for · {g.tag}</div>
+                <div className="body-prose" style={{ fontSize: 15, marginTop: 8, color: 'var(--t-ink-soft)' }}>{g.desc}</div>
+                <div className="serif-italic" style={{ fontSize: 14, fontStyle: 'italic', marginTop: 8, color: 'var(--t-ink-faint)' }}>
+                  sample · {g.sample}
+                </div>
+              </div>
+              <div style={{ fontFamily: 'var(--t-mono)', fontSize: 10, color: 'var(--t-ink-faint)', letterSpacing: '0.14em' }}>
+                {pick === g.id ? '● selected' : '○ pick'}
+              </div>
+            </button>
+          );
+        })}
+
+        <div className="card bare" onClick={openCreateGuide} style={{
+          display: 'flex', alignItems: 'center', gap: 16, padding: '14px 22px', cursor: 'pointer',
+        }}>
+          <div style={{
+            width: 60, height: 60, borderRadius: '50%',
+            border: '1.5px dashed var(--t-ink-faint)',
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+            fontFamily: 'var(--t-display)', fontStyle: 'italic', fontSize: 28, color: 'var(--t-ink-faint)',
+          }}>+</div>
+          <div style={{ flex: 1 }}>
+            <div className="serif-italic" style={{ fontSize: 20, color: 'var(--t-ink)' }}>Create your own guide</div>
+            <div className="muted" style={{ fontFamily: 'var(--t-mono)', fontSize: 11, marginTop: 2 }}>
+              describe how you want to be paid attention to · share it via link
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="divider-flourish"/>
+
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <span className="muted" style={{ fontFamily: 'var(--t-mono)', fontSize: 11 }}>
+          guide rules: ask · mirror · propose structure · never draft
+        </span>
+        <button className="btn primary" onClick={go}>begin with {MASCOTS[pick].name} →</button>
+      </div>
+    </div>
+  );
+}
+
+// ─────────── INTERVIEW (split A — with live mascot emotion) ───────────
+
+function Interview({ go, setEmotion }) {
+  const [qIdx, setQIdx] = React.useState(0);
+  const [answers, setAnswers] = React.useState(SCRIPT.interview.map(() => ''));
+  const [showMirror, setShowMirror] = React.useState(false);
+  const cur = SCRIPT.interview[qIdx];
+
+  React.useEffect(() => { setEmotion(cur.mood); }, [qIdx]);
+
+  const onChange = e => {
+    const next = [...answers]; next[qIdx] = e.target.value;
+    setAnswers(next);
+    if (e.target.value.length > 60 && !showMirror) setShowMirror(true);
+  };
+  const next = () => {
+    setShowMirror(false);
+    if (qIdx < SCRIPT.interview.length - 1) setQIdx(qIdx + 1);
+    else go();
+  };
+
+  // pre-fill demo answers when stepping
+  React.useEffect(() => {
+    if (!answers[qIdx]) {
+      const t = setTimeout(() => {
+        const next = [...answers]; next[qIdx] = SCRIPT.interview[qIdx].a;
+        setAnswers(next);
+        setShowMirror(true);
+      }, 400);
+      return () => clearTimeout(t);
+    }
+  }, [qIdx]);
+
+  return (
+    <div className="stage" style={{ maxWidth: 1180 }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 22 }}>
+        <div className="eyebrow">interview · {MASCOTS[SCRIPT.mascot].guide}</div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+          <span className="muted" style={{ fontFamily: 'var(--t-mono)', fontSize: 10 }}>q{qIdx + 1} / {SCRIPT.interview.length}</span>
+          <div className="progress-dots">
+            {SCRIPT.interview.map((_, i) => <div key={i} className={'d ' + (i <= qIdx ? 'on' : '')}/>)}
+          </div>
+        </div>
+      </div>
+
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 56, alignItems: 'start' }}>
+        {/* LEFT — guide side */}
+        <div style={{ paddingTop: 8, position: 'relative' }}>
+          <div style={{ marginBottom: 22 }}>
+            <MascotView id={SCRIPT.mascot} emotion={cur.mood} size={84}/>
+          </div>
+          <div className="eyebrow" style={{ marginBottom: 10 }}>the guide is asking</div>
+          <div className="serif-italic" style={{ fontSize: 36, lineHeight: 1.2, color: 'var(--t-ink)' }}>
+            {cur.q}
+          </div>
+
+          {showMirror && qIdx > 0 && (
+            <div className="card" style={{
+              marginTop: 28, padding: '14px 18px',
+              borderLeft: '2px solid var(--t-accent)',
+              animation: 'fadein 600ms ease',
+            }}>
+              <div className="eyebrow" style={{ color: 'var(--t-accent)' }}>holding · from your last answer</div>
+              <div className="serif-italic" style={{ fontSize: 18, fontStyle: 'italic', marginTop: 6, color: 'var(--t-ink)' }}>
+                "<span className="hl">{SCRIPT.interview[qIdx-1].a.split(/[.!?]/)[0]}</span>"
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* RIGHT — user side */}
+        <div>
+          <div className="eyebrow" style={{ marginBottom: 10 }}>your turn · take your time</div>
+          <textarea
+            className="textarea-prose"
+            value={answers[qIdx]}
+            onChange={onChange}
+            rows={7}
+            placeholder="something specific. one detail is enough."
+            style={{ fontSize: 19, minHeight: 200 }}
+          />
+          <div style={{ display: 'flex', justifyContent: 'space-between', marginTop: 14, alignItems: 'center' }}>
+            <span className="muted" style={{ fontFamily: 'var(--t-mono)', fontSize: 10 }}>
+              {answers[qIdx].split(/\s+/).filter(Boolean).length} words · all yours
+            </span>
+            <div style={{ display: 'flex', gap: 8 }}>
+              <button className="btn ghost sm">↺ rephrase</button>
+              <button className="btn primary" onClick={next}>
+                {qIdx < SCRIPT.interview.length - 1 ? 'next →' : 'find the spine →'}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+Object.assign(window, { SCRIPT, PickMoment, GuidePicker, Interview });

--- a/docs/design/hifi/screens-2.jsx
+++ b/docs/design/hifi/screens-2.jsx
@@ -1,0 +1,335 @@
+// Mean It hi-fi — Spine, Drafting, Render screens.
+
+// ─────────── SPINE + STRUCTURE ───────────
+
+function Spine({ go, setEmotion }) {
+  const [pick, setPick] = React.useState(0);
+  React.useEffect(() => { setEmotion('moved'); }, []);
+
+  return (
+    <div className="stage">
+      <div className="eyebrow">spine · the line everything else hangs from</div>
+      <h1 className="h-display smaller" style={{ marginTop: 8, marginBottom: 8 }}>
+        Three of your phrases.<br/>One of them is the heart.
+      </h1>
+      <div className="body-prose" style={{ maxWidth: 580, marginBottom: 28 }}>
+        Every phrase below is your verbatim text. Pick the one this letter is built around.
+      </div>
+
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: 14 }}>
+        {SCRIPT.spineCandidates.map((p, i) => (
+          <button key={i} onClick={() => setPick(i)}
+            className={'card ' + (pick === i ? 'selected' : 'outlined')}
+            style={{ textAlign: 'left', cursor: 'pointer', padding: '20px 22px',
+                     fontFamily: 'inherit', color: 'inherit', minHeight: 200,
+                     display: 'flex', flexDirection: 'column', justifyContent: 'space-between' }}>
+            <div>
+              <div className="eyebrow">phrase 0{i+1}</div>
+              <div className="serif-italic" style={{ fontSize: 22, lineHeight: 1.3, marginTop: 10, color: 'var(--t-ink)' }}>
+                "{p.t}"
+              </div>
+            </div>
+            <div className="muted" style={{ fontFamily: 'var(--t-mono)', fontSize: 10, marginTop: 16 }}>
+              {pick === i ? '● this is the spine' : 'from · ' + p.from}
+            </div>
+          </button>
+        ))}
+      </div>
+
+      <div className="divider-flourish"/>
+
+      <div className="eyebrow" style={{ marginBottom: 12 }}>structure the guide proposes — three movements</div>
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 14 }}>
+        {SCRIPT.structure.map((s, i) => (
+          <div key={i} className="card outlined" style={{ padding: '18px 22px' }}>
+            <div className="eyebrow" style={{ color: 'var(--t-accent)' }}>movement {i+1}</div>
+            <div className="serif-italic" style={{ fontSize: 22, marginTop: 6, color: 'var(--t-ink)' }}>{s.label}</div>
+            <div className="muted" style={{ fontFamily: 'var(--t-mono)', fontSize: 10, marginTop: 4 }}>{s.sub}</div>
+            <div style={{
+              marginTop: 16, padding: '14px 12px',
+              border: '1px dashed var(--t-ink-faint)', borderRadius: 'var(--t-radius)',
+              fontFamily: 'var(--t-mono)', fontSize: 10, color: 'var(--t-ink-faint)',
+              textAlign: 'center', letterSpacing: '0.1em', textTransform: 'uppercase',
+            }}>your words · go here</div>
+          </div>
+        ))}
+      </div>
+
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginTop: 36 }}>
+        <span className="muted" style={{ fontFamily: 'var(--t-mono)', fontSize: 11 }}>swap or drop any movement · this is yours</span>
+        <button className="btn primary" onClick={go}>start writing →</button>
+      </div>
+    </div>
+  );
+}
+
+// ─────────── DRAFTING (streaming critique, A) ───────────
+
+function Drafting({ go, setEmotion }) {
+  const [text, setText] = React.useState('');
+  const [critiques, setCritiques] = React.useState([]);
+  const target = SCRIPT.draft.map(d => d.text).join('\n');
+  const [step, setStep] = React.useState(0);
+
+  React.useEffect(() => { setEmotion('listening'); }, []);
+
+  // simulate typing on mount
+  React.useEffect(() => {
+    if (step >= target.length) return;
+    const t = setTimeout(() => {
+      setText(target.slice(0, step + 1));
+      setStep(step + 1);
+      // mood beats while typing
+      const ch = target[step];
+      if (ch === '\n') {
+        const lineIdx = target.slice(0, step).split('\n').length - 1;
+        const line = SCRIPT.draft[lineIdx];
+        if (line) {
+          if (line.flag === 'cliche') {
+            setEmotion('sad');
+            setCritiques(c => [...c, {
+              kind: 'cliche', line: line.text,
+              note: 'this one is borrowed. you noticed a notebook of strangers\' names — keep going specific.',
+            }]);
+          } else if (line.verified) {
+            setEmotion('moved');
+            setCritiques(c => [...c, {
+              kind: 'verified', line: line.text,
+              note: 'verified yours · from ' + line.src,
+            }]);
+          }
+        }
+      }
+    }, 18);
+    return () => clearTimeout(t);
+  }, [step]);
+
+  const lines = text.split('\n');
+  const bylinePct = Math.round(
+    (SCRIPT.draft.slice(0, lines.length).filter(d => d.verified).length / Math.max(lines.length, 1)) * 100
+  );
+
+  return (
+    <div className="stage" style={{ maxWidth: 1180 }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 22 }}>
+        <div className="eyebrow">drafting · streaming critique</div>
+        <div className="byline">
+          <span className="byline-dot"/>
+          <span>{bylinePct}% verified yours · {lines.length} / {SCRIPT.draft.length} lines</span>
+        </div>
+      </div>
+
+      <div style={{ display: 'grid', gridTemplateColumns: '1.5fr 1fr', gap: 48 }}>
+        {/* LEFT — draft */}
+        <div>
+          <div className="eyebrow" style={{ marginBottom: 12 }}>your letter · for tomas</div>
+          <div className="card outlined" style={{
+            padding: '32px 36px', minHeight: 380,
+            fontFamily: 'var(--t-body)', fontSize: 19, lineHeight: 1.75,
+            color: 'var(--t-ink)',
+          }}>
+            {lines.map((ln, i) => {
+              const meta = SCRIPT.draft[i];
+              const flagged = meta && meta.flag === 'cliche';
+              return (
+                <div key={i} style={{
+                  background: flagged ? 'var(--t-accent-soft)' : 'transparent',
+                  textDecoration: flagged ? 'underline wavy var(--t-accent)' : 'none',
+                  borderRadius: 2, padding: '0 2px',
+                }}>
+                  {ln || <span style={{ opacity: 0.3 }}>·</span>}
+                </div>
+              );
+            })}
+            <span style={{
+              display: 'inline-block', width: 1.5, height: 20, background: 'var(--t-ink)',
+              animation: 'blink 1s infinite', verticalAlign: 'middle',
+            }}/>
+          </div>
+        </div>
+
+        {/* RIGHT — critique stream */}
+        <div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 12 }}>
+            <MascotView id={SCRIPT.mascot} emotion={critiques.find(c=>c.kind==='cliche') ? 'sad' : 'listening'} size={48}/>
+            <div className="eyebrow">guide · just notes</div>
+          </div>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 12, maxHeight: 460, overflow: 'auto' }} className="no-scrollbar">
+            {critiques.slice().reverse().map((c, i) => (
+              <div key={i} className="card outlined" style={{
+                padding: '12px 16px',
+                borderColor: c.kind === 'cliche' ? 'var(--t-accent)' : 'var(--t-ink-ghost)',
+                borderLeft: '2px solid ' + (c.kind === 'cliche' ? 'var(--t-accent)' : 'var(--t-verified)'),
+                animation: 'fadein 400ms ease',
+              }}>
+                <div className="eyebrow" style={{ color: c.kind === 'cliche' ? 'var(--t-accent)' : 'var(--t-verified)' }}>
+                  {c.kind === 'cliche' ? '⚠ cliché · borrowed phrase' : '✓ verified yours'}
+                </div>
+                <div style={{ fontFamily: 'var(--t-body)', fontSize: 14, marginTop: 6, color: 'var(--t-ink-soft)', lineHeight: 1.5 }}>
+                  {c.note}
+                </div>
+                {c.kind === 'cliche' && (
+                  <div style={{ display: 'flex', gap: 8, marginTop: 10 }}>
+                    <button className="btn ghost sm">cut it</button>
+                    <button className="btn ghost sm">i'll keep it</button>
+                  </div>
+                )}
+              </div>
+            ))}
+            {critiques.length === 0 && (
+              <div className="muted" style={{ fontFamily: 'var(--t-mono)', fontSize: 11, padding: 12 }}>
+                listening as you write…
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <div style={{ display: 'flex', justifyContent: 'flex-end', marginTop: 28 }}>
+        <button className="btn primary" onClick={go}>render the artifact →</button>
+      </div>
+    </div>
+  );
+}
+
+// ─────────── RENDER + HOVER TRACE ───────────
+
+function Render({ openDownload, openSave, openShare, openStartOver, openReel, setEmotion }) {
+  const [hovered, setHovered] = React.useState(null);
+  const [pos, setPos] = React.useState({ x: 0, y: 0 });
+  React.useEffect(() => { setEmotion('hopeful'); }, []);
+
+  // skip the cliché line — user "cut it"
+  const finalLines = SCRIPT.draft.filter(d => d.verified);
+  const total = finalLines.reduce((n, d) => n + d.text.split(/\s+/).length, 0);
+  const verified = total; // 100% after cut
+
+  const lineToQuestion = (src) => SCRIPT.interview.find((_, i) => 'q' + (i+1) === src);
+
+  return (
+    <div className="stage" style={{ maxWidth: 760, paddingTop: 64 }}>
+      {/* postmark — top right of the artifact */}
+      <div className="corner-stamp">
+        <div className="postmark">
+          <div className="pm-top">verified · yours</div>
+          <div className="pm-mid">100%</div>
+          <div className="pm-bot">mean it · 2025</div>
+        </div>
+      </div>
+
+      <div style={{ textAlign: 'center', marginBottom: 36 }}>
+        <div className="eyebrow">for tomas · read aloud, saturday</div>
+        <div className="ornament" style={{ marginTop: 12 }}>
+          <svg width="120" height="14" viewBox="0 0 120 14" style={{ display: 'inline' }}>
+            <path d="M 4 7 Q 30 2, 60 7 T 116 7" stroke="currentColor" strokeWidth="1" fill="none"/>
+            <circle cx="60" cy="7" r="2" fill="currentColor"/>
+          </svg>
+        </div>
+      </div>
+
+      <article style={{
+        fontFamily: 'var(--t-body)',
+        fontSize: 24,
+        lineHeight: 1.75,
+        textAlign: 'center',
+        color: 'var(--t-ink)',
+      }}>
+        {finalLines.map((ln, i) => {
+          const q = lineToQuestion(ln.src);
+          return (
+            <div key={i}
+              className="trace-line"
+              style={{ marginBottom: i === finalLines.length - 2 ? 18 : 4 }}
+              onMouseEnter={e => { setHovered({ ln, q }); setPos({ x: e.clientX, y: e.clientY }); }}
+              onMouseMove={e => setPos({ x: e.clientX, y: e.clientY })}
+              onMouseLeave={() => setHovered(null)}
+            >
+              {ln.text}
+            </div>
+          );
+        })}
+      </article>
+
+      <div className="divider-flourish" style={{ marginTop: 64 }}>
+        <span className="ornament-glyph">❦</span>
+      </div>
+
+      <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', gap: 14, marginBottom: 8 }}>
+        <div className="seal" style={{ width: 44, height: 44 }}>
+          <span className="seal-glyph" style={{ fontSize: 18 }}>M</span>
+        </div>
+        <div className="serif-italic" style={{ fontSize: 22, color: 'var(--t-ink)' }}>
+          One hundred percent your words.
+        </div>
+      </div>
+      <div className="muted" style={{ fontFamily: 'var(--t-mono)', fontSize: 10, textAlign: 'center', letterSpacing: '0.14em' }}>
+        every line · hover · see the question that prompted it
+      </div>
+
+      <div style={{ display: 'flex', justifyContent: 'center', gap: 10, marginTop: 28, flexWrap: 'wrap' }}>
+        <button className="btn ghost sm" onClick={openDownload}>↓ download</button>
+        <button className="btn ghost sm" onClick={openSave}>♡ save</button>
+        <button className="btn ghost sm" onClick={openShare}>↗ share trace</button>
+        <button className="btn sm" onClick={openStartOver}>start over</button>
+      </div>
+
+      {/* MAKE IT MOVE — featured CTA */}
+      <div className="divider-flourish" style={{ marginTop: 36 }}><span className="ornament-glyph">·</span></div>
+      <div className="card raised" style={{
+        marginTop: 8, padding: '22px 26px',
+        display: 'grid', gridTemplateColumns: '1fr auto', gap: 24, alignItems: 'center',
+        background: 'var(--t-paper-warm)', position: 'relative', overflow: 'hidden',
+      }}>
+        {/* tiny phone-frame accent */}
+        <div style={{ position: 'absolute', top: -10, right: 130, transform: 'rotate(6deg)', opacity: 0.85 }}>
+          <div style={{
+            width: 46, height: 84, borderRadius: 8,
+            border: '2px solid var(--t-ink)',
+            background: 'linear-gradient(155deg, color-mix(in srgb, var(--t-accent) 50%, var(--t-paper)), var(--t-paper-warm))',
+            position: 'relative',
+          }}>
+            <div style={{ position: 'absolute', left: '50%', top: 4, transform: 'translateX(-50%)', width: 12, height: 2, background: 'var(--t-ink)', borderRadius: 1 }}/>
+            <div style={{ position: 'absolute', left: 4, right: 4, bottom: 6, fontFamily: 'var(--t-display)', fontStyle: 'italic', fontSize: 5.5, lineHeight: 1.1, color: 'var(--t-ink)', textAlign: 'center' }}>
+              "the world is wide…"
+            </div>
+          </div>
+        </div>
+        <div>
+          <div className="eyebrow accent">new · for letters that should be seen</div>
+          <h3 className="serif-italic" style={{ fontSize: 28, color: 'var(--t-ink)', marginTop: 6, marginBottom: 6, fontStyle: 'italic' }}>
+            Make it move.
+          </h3>
+          <div className="body-prose" style={{ fontSize: 14, maxWidth: 540 }}>
+            Turn this letter into a 30-second reel. Drop in photos, read it aloud in your voice, and we'll cut it to 9:16 — captions, your audio, and the trace badge on the end card.
+          </div>
+        </div>
+        <button className="btn primary" onClick={openReel} style={{ whiteSpace: 'nowrap' }}>
+          ▶ make a reel
+        </button>
+      </div>
+
+      {hovered && (
+        <div className="trace-pop" style={{
+          left: Math.min(pos.x + 16, window.innerWidth - 340),
+          top: Math.max(pos.y - 100, 20),
+        }}>
+          <div className="eyebrow" style={{ color: 'var(--t-accent)' }}>trace · {hovered.ln.src}</div>
+          <div className="muted" style={{ fontFamily: 'var(--t-mono)', fontSize: 9, marginTop: 8 }}>question</div>
+          <div className="serif-italic" style={{ fontSize: 14, marginTop: 2, color: 'var(--t-ink)' }}>
+            "{hovered.q?.q}"
+          </div>
+          <div className="muted" style={{ fontFamily: 'var(--t-mono)', fontSize: 9, marginTop: 10 }}>your verbatim answer</div>
+          <div style={{ fontSize: 13, marginTop: 4, color: 'var(--t-ink-soft)', fontStyle: 'italic' }}>
+            "{hovered.q?.a}"
+          </div>
+          <div style={{
+            marginTop: 12, paddingTop: 10, borderTop: '1px solid var(--t-ink-ghost)',
+            fontFamily: 'var(--t-mono)', fontSize: 9, color: 'var(--t-verified)', letterSpacing: '0.1em', textTransform: 'uppercase',
+          }}>✓ exact substring · verified yours</div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+Object.assign(window, { Spine, Drafting, Render });

--- a/docs/design/hifi/screens-3.jsx
+++ b/docs/design/hifi/screens-3.jsx
@@ -1,0 +1,304 @@
+// Mean It hi-fi — Create-Your-Own-Guide flow (hybrid: single screen, guided sequence inside).
+
+function CreateGuideDialog({ onClose }) {
+  const [step, setStep] = React.useState(0); // 0..4 = guided questions; 5 = preview/edit; 6 = done
+  const [data, setData] = React.useState({
+    name: '',
+    pulls_for: '',
+    voice: '',
+    sample_q: '',
+    never: '',
+    mascot: 'wren',
+  });
+
+  const set = (k, v) => setData(d => ({ ...d, [k]: v }));
+
+  const questions = [
+    {
+      id: 'pulls_for',
+      eyebrow: 'question 01 · what do they pull for',
+      q: 'What does this guide listen for?',
+      sub: 'The thing they hear when nobody else is hearing it.',
+      placeholder: 'e.g. "the small, specific gesture nobody noticed but you"',
+      examples: ['memory · specifics', 'the unsaid feeling', 'sensory detail', 'the contradiction'],
+    },
+    {
+      id: 'voice',
+      eyebrow: 'question 02 · how do they sound',
+      q: 'How would you describe their voice?',
+      sub: 'Three words is plenty. Or a sentence. Or a feeling.',
+      placeholder: 'e.g. "patient. low-key. comfortable with silence."',
+      examples: ['curious · gentle', 'sharp · interrupting', 'warm · slow'],
+    },
+    {
+      id: 'sample_q',
+      eyebrow: 'question 03 · the kind of question they ask',
+      q: 'Write a question they\'d ask you.',
+      sub: 'One sample question that captures how they pull a story.',
+      placeholder: 'e.g. "When you picture their hands — what are they doing?"',
+      examples: [],
+    },
+    {
+      id: 'never',
+      eyebrow: 'question 04 · the rule they live by',
+      q: 'What would they never do?',
+      sub: 'Hard limits. The things you don\'t want this guide saying.',
+      placeholder: 'e.g. "never finish your sentence. never offer a metaphor."',
+      examples: ['never write for me', 'never cliché', 'never rush'],
+    },
+    {
+      id: 'name',
+      eyebrow: 'question 05 · the name',
+      q: 'What\'s their name?',
+      sub: 'A name and a one-line title. The mascot art comes from us.',
+      placeholder: 'e.g. "Marsh — the slow listener"',
+      examples: [],
+    },
+  ];
+
+  const cur = questions[step];
+  const filled = step <= 4 ? !!data[cur.id]?.trim() : true;
+
+  const next = () => {
+    if (step < questions.length - 1) setStep(step + 1);
+    else setStep(5);
+  };
+  const prev = () => { if (step > 0) setStep(step - 1); };
+
+  return (
+    <div className="scrim" onClick={onClose}>
+      <div className="dialog" style={{ maxWidth: 760, padding: 0, overflow: 'hidden' }} onClick={e => e.stopPropagation()}>
+        <button className="close" onClick={onClose}>esc · close</button>
+
+        {/* tape decoration */}
+        <div className="tape tl"/>
+        <div className="tape tr"/>
+
+        <div style={{ padding: '36px 40px 32px' }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-end', marginBottom: 8 }}>
+            <div>
+              <div className="eyebrow accent">create your own guide</div>
+              <h2 className="h-display tiny" style={{ marginTop: 6 }}>
+                {step <= 4 ? 'A guided interview · for the guide.' : 'Here they are.'}
+              </h2>
+            </div>
+            <div className="progress-dots">
+              {[0,1,2,3,4,5].map(i => <div key={i} className={'d ' + (i <= step ? 'on' : '')}/>)}
+            </div>
+          </div>
+
+          {step <= 4 && (
+            <div style={{ marginTop: 28, animation: 'fadein 300ms ease' }} key={step}>
+              <div className="eyebrow" style={{ marginBottom: 10 }}>{cur.eyebrow}</div>
+              <div className="serif-italic" style={{ fontSize: 32, lineHeight: 1.18, color: 'var(--t-ink)', marginBottom: 6 }}>
+                {cur.q}
+              </div>
+              <div className="body-prose" style={{ fontSize: 15, marginBottom: 18, color: 'var(--t-ink-soft)' }}>
+                {cur.sub}
+              </div>
+
+              <textarea
+                className="textarea-prose"
+                rows={cur.id === 'sample_q' || cur.id === 'voice' ? 3 : 2}
+                value={data[cur.id]}
+                onChange={e => set(cur.id, e.target.value)}
+                placeholder={cur.placeholder}
+                style={{ fontSize: 17 }}
+                autoFocus
+              />
+
+              {cur.examples.length > 0 && (
+                <div style={{ marginTop: 12 }}>
+                  <div className="eyebrow" style={{ marginBottom: 6 }}>or borrow one</div>
+                  <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+                    {cur.examples.map(ex => (
+                      <button key={ex} className="tag" onClick={() => set(cur.id, ex)}>{ex}</button>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {/* live preview — small card showing the guide forming */}
+              <div style={{ marginTop: 22 }}>
+                <div className="eyebrow" style={{ marginBottom: 8 }}>forming…</div>
+                <div className="plate" style={{
+                  padding: '14px 18px',
+                  display: 'grid', gridTemplateColumns: '60px 1fr', gap: 14, alignItems: 'center',
+                }}>
+                  <div style={{
+                    width: 60, height: 60, display: 'flex', alignItems: 'center', justifyContent: 'center',
+                    border: '1.5px dashed var(--t-ink-faint)', borderRadius: '50%',
+                  }}>
+                    <span style={{ fontFamily: 'var(--t-display)', fontStyle: 'italic', fontSize: 28, color: 'var(--t-ink-faint)' }}>?</span>
+                  </div>
+                  <div>
+                    <div className="serif-italic" style={{ fontSize: 20, color: 'var(--t-ink)' }}>
+                      {data.name || <span className="muted">— unnamed —</span>}
+                    </div>
+                    <div className="muted" style={{ fontFamily: 'var(--t-mono)', fontSize: 10, marginTop: 4, letterSpacing: '0.12em' }}>
+                      pulls for · {data.pulls_for || '—'}
+                    </div>
+                    {data.voice && (
+                      <div className="body-prose" style={{ fontSize: 13, marginTop: 6, color: 'var(--t-ink-soft)' }}>
+                        voice · {data.voice}
+                      </div>
+                    )}
+                    {data.sample_q && (
+                      <div className="serif-italic" style={{ fontSize: 13, fontStyle: 'italic', marginTop: 6, color: 'var(--t-ink-faint)' }}>
+                        sample · "{data.sample_q}"
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </div>
+
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginTop: 24 }}>
+                <button className="btn ghost sm" onClick={prev} disabled={step === 0} style={{ opacity: step === 0 ? 0.4 : 1 }}>← back</button>
+                <span className="muted" style={{ fontFamily: 'var(--t-mono)', fontSize: 10 }}>
+                  {step + 1} of {questions.length}
+                </span>
+                <button className="btn primary" onClick={next} disabled={!filled} style={{ opacity: filled ? 1 : 0.4 }}>
+                  {step < questions.length - 1 ? 'next →' : 'preview →'}
+                </button>
+              </div>
+            </div>
+          )}
+
+          {step === 5 && (
+            <div style={{ marginTop: 24, animation: 'fadein 360ms ease' }}>
+              <div className="body-prose" style={{ fontSize: 16, marginBottom: 22 }}>
+                Here's what you made. Edit any field directly — or stamp it and use it.
+              </div>
+
+              <div style={{ display: 'grid', gridTemplateColumns: '1.1fr 1fr', gap: 28 }}>
+                {/* LEFT — the guide card preview */}
+                <div className="plate raised" style={{ padding: 22, position: 'relative' }}>
+                  <div className="corner-stamp" style={{ top: 12, right: 12 }}>
+                    <div style={{
+                      border: '1.5px solid var(--t-accent)', color: 'var(--t-accent)',
+                      fontFamily: 'var(--t-stamp)', fontSize: 9, padding: '3px 8px',
+                      letterSpacing: '0.12em', textTransform: 'uppercase', transform: 'rotate(-4deg)',
+                    }}>custom</div>
+                  </div>
+
+                  <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', marginBottom: 14 }}>
+                    <MascotView id={data.mascot} emotion="curious" size={84}/>
+                  </div>
+                  <div className="serif-italic" style={{ fontSize: 26, color: 'var(--t-ink)', textAlign: 'center', marginBottom: 4 }}>
+                    {data.name || 'Unnamed'}
+                  </div>
+                  <div className="muted" style={{ fontFamily: 'var(--t-mono)', fontSize: 9, letterSpacing: '0.16em', textAlign: 'center', marginBottom: 14, textTransform: 'uppercase' }}>
+                    pulls for · {data.pulls_for || '—'}
+                  </div>
+
+                  <div className="body-prose" style={{ fontSize: 14, marginBottom: 12 }}>
+                    {data.voice || <span className="muted">— no voice description —</span>}
+                  </div>
+
+                  <div className="serif-italic" style={{ fontSize: 14, fontStyle: 'italic', color: 'var(--t-ink-soft)', borderLeft: '2px solid var(--t-accent)', paddingLeft: 12, marginBottom: 12 }}>
+                    "{data.sample_q}"
+                  </div>
+
+                  {data.never && (
+                    <div className="muted" style={{ fontFamily: 'var(--t-mono)', fontSize: 11, color: 'var(--t-accent)', letterSpacing: '0.12em' }}>
+                      never · {data.never}
+                    </div>
+                  )}
+
+                  <div style={{ marginTop: 18, paddingTop: 12, borderTop: '1px dashed var(--t-ink-ghost)' }}>
+                    <div className="eyebrow" style={{ marginBottom: 8 }}>mascot art · pick one</div>
+                    <div style={{ display: 'flex', gap: 10, justifyContent: 'center' }}>
+                      {['wren', 'pip', 'cassio'].map(m => (
+                        <button key={m} onClick={() => set('mascot', m)}
+                          style={{
+                            background: 'transparent', cursor: 'pointer',
+                            border: data.mascot === m ? '1.5px solid var(--t-accent)' : '1.5px solid var(--t-ink-ghost)',
+                            borderRadius: 'var(--t-radius)', padding: 4,
+                          }}>
+                          <MascotView id={m} emotion="listening" size={42}/>
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+
+                {/* RIGHT — editable raw fields */}
+                <div>
+                  <div className="eyebrow" style={{ marginBottom: 10 }}>raw fields · editable</div>
+                  {[
+                    { k: 'name',       label: 'name + title' },
+                    { k: 'pulls_for',  label: 'pulls for' },
+                    { k: 'voice',      label: 'voice' },
+                    { k: 'sample_q',   label: 'sample question' },
+                    { k: 'never',      label: 'never · hard limit' },
+                  ].map(f => (
+                    <div key={f.k} style={{ marginBottom: 12 }}>
+                      <div className="muted" style={{ fontFamily: 'var(--t-mono)', fontSize: 9, letterSpacing: '0.14em', marginBottom: 4, textTransform: 'uppercase' }}>{f.label}</div>
+                      <input
+                        type="text"
+                        value={data[f.k]}
+                        onChange={e => set(f.k, e.target.value)}
+                        style={{
+                          width: '100%',
+                          background: 'var(--t-paper-warm)',
+                          border: '1px solid var(--t-ink-ghost)',
+                          borderRadius: 'var(--t-radius)',
+                          padding: '8px 10px',
+                          fontFamily: 'var(--t-body)', fontSize: 14,
+                          color: 'var(--t-ink)', outline: 'none',
+                        }}
+                      />
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              <div className="divider-flourish"><span className="ornament-glyph">❦</span></div>
+
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                <button className="btn ghost sm" onClick={() => setStep(0)}>↺ start over</button>
+                <div style={{ display: 'flex', gap: 8 }}>
+                  <button className="btn sm" onClick={() => setStep(6)}>↗ share guide</button>
+                  <button className="btn primary" onClick={() => setStep(6)}>stamp & use →</button>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {step === 6 && (
+            <div style={{ padding: '20px 0 8px', textAlign: 'center', animation: 'fadein 400ms ease' }}>
+              <div style={{ display: 'flex', justifyContent: 'center', marginBottom: 24 }}>
+                <StampMark color="var(--t-verified)">stamped · ready</StampMark>
+              </div>
+
+              <div style={{ display: 'flex', justifyContent: 'center', marginBottom: 16 }}>
+                <MascotView id={data.mascot} emotion="hopeful" size={96}/>
+              </div>
+
+              <div className="serif-italic" style={{ fontSize: 30, color: 'var(--t-ink)', marginBottom: 6 }}>
+                {data.name || 'your guide'} is ready.
+              </div>
+              <div className="body-prose" style={{ fontSize: 15, marginBottom: 22 }}>
+                Saved to your guide library. They'll show up next to Wren, Pip, and Cassio.
+              </div>
+
+              <div className="eyebrow" style={{ marginBottom: 8 }}>share link · anyone can import them</div>
+              <div style={{ maxWidth: 480, margin: '0 auto' }}>
+                <CopyLine url={'meanit.app/guide/' + (data.name || 'unnamed').toLowerCase().replace(/\s+/g, '-').slice(0, 24)}/>
+              </div>
+
+              <div className="divider-flourish"><span className="ornament-glyph">·</span></div>
+
+              <div style={{ display: 'flex', justifyContent: 'center', gap: 10 }}>
+                <button className="btn sm" onClick={() => { setStep(0); setData({ name: '', pulls_for: '', voice: '', sample_q: '', never: '', mascot: 'wren' }); }}>make another</button>
+                <button className="btn primary" onClick={onClose}>back to guide picker →</button>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+Object.assign(window, { CreateGuideDialog });

--- a/docs/design/hifi/theme.css
+++ b/docs/design/hifi/theme.css
@@ -1,0 +1,893 @@
+/* ─────────────────────────────────────────────────────────────
+   Mean It — letterpress / stationery identity.
+   Five themes (cute → warm → quiet → noir → gothic).
+   Visual vocabulary: deckle paper, postal motifs, debossed plates,
+   wax seals, tape, ink-block stamps. Type: editorial display + mono UI.
+   ───────────────────────────────────────────────────────────── */
+
+:root {
+  /* default = warm */
+  --t-bg: #ece2cf;
+  --t-paper: #f5ecd9;
+  --t-paper-warm: #ede2c8;
+  --t-paper-shadow: rgba(58, 36, 14, 0.18);
+  --t-paper-highlight: rgba(255, 248, 230, 0.85);
+
+  --t-ink: #1d150c;
+  --t-ink-soft: #4a3a26;
+  --t-ink-faint: rgba(29, 21, 12, 0.46);
+  --t-ink-ghost: rgba(29, 21, 12, 0.14);
+
+  --t-accent: #8b2418;          /* postal red */
+  --t-accent-deep: #5e1810;
+  --t-accent-soft: rgba(139, 36, 24, 0.14);
+  --t-seal: #8b2418;            /* wax seal */
+
+  --t-highlight: #e6c64f;       /* highlighter */
+  --t-verified: #4a6b3a;
+  --t-tape: rgba(212, 184, 130, 0.65);
+
+  --t-display: 'Playfair Display', 'Iowan Old Style', Georgia, serif;
+  --t-body: 'EB Garamond', 'Iowan Old Style', Georgia, serif;
+  --t-mono: 'JetBrains Mono', 'IBM Plex Mono', ui-monospace, monospace;
+  --t-hand: 'Caveat', cursive;
+  --t-stamp: 'Special Elite', 'Courier Prime', 'Courier New', monospace;
+  --t-display-style: italic;
+  --t-display-weight: 600;
+
+  --t-radius: 1px;
+  --t-ornament-color: rgba(139, 36, 24, 0.55);
+  --t-anim-speed: 1;
+
+  /* paper texture, layered */
+  --t-grain: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='320' height='320'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.92' numOctaves='2' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 0.12  0 0 0 0 0.08  0 0 0 0 0.04  0 0 0 0.7 0'/></filter><rect width='100%' height='100%' filter='url(%23n)' opacity='0.55'/></svg>");
+  --t-fibers: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='600' height='600'><filter id='f'><feTurbulence type='turbulence' baseFrequency='0.012 0.4' numOctaves='2' seed='3'/><feColorMatrix values='0 0 0 0 0.18  0 0 0 0 0.10  0 0 0 0 0.04  0 0 0 0.18 0'/></filter><rect width='100%' height='100%' filter='url(%23f)'/></svg>");
+}
+
+/* ─────────── theme: cute ─────────── */
+.theme-cute {
+  --t-bg: #fce6e4;
+  --t-paper: #fff2ee;
+  --t-paper-warm: #ffe2dc;
+  --t-paper-shadow: rgba(120, 40, 50, 0.14);
+  --t-paper-highlight: rgba(255, 250, 248, 0.9);
+  --t-ink: #4a2030;
+  --t-ink-soft: #7a4050;
+  --t-ink-faint: rgba(74, 32, 48, 0.46);
+  --t-ink-ghost: rgba(74, 32, 48, 0.13);
+  --t-accent: #d34860;
+  --t-accent-deep: #9a2a3c;
+  --t-accent-soft: rgba(211, 72, 96, 0.16);
+  --t-seal: #d34860;
+  --t-highlight: #ffd66b;
+  --t-verified: #6e8a3e;
+  --t-tape: rgba(255, 200, 180, 0.7);
+  --t-display: 'Fraunces', 'Playfair Display', Georgia, serif;
+  --t-body: 'EB Garamond', Georgia, serif;
+  --t-display-weight: 700;
+  --t-display-style: normal;
+  --t-radius: 6px;
+  --t-ornament-color: rgba(211, 72, 96, 0.7);
+  --t-anim-speed: 1.6;
+}
+
+/* ─────────── theme: warm (default) ─────────── */
+.theme-warm { /* uses :root values */ }
+
+/* ─────────── theme: quiet ─────────── */
+.theme-quiet {
+  --t-bg: #e7e4d8;
+  --t-paper: #f0ede0;
+  --t-paper-warm: #e6e2d2;
+  --t-paper-shadow: rgba(40, 38, 30, 0.16);
+  --t-paper-highlight: rgba(252, 250, 240, 0.85);
+  --t-ink: #1f1d18;
+  --t-ink-soft: #3e3a30;
+  --t-ink-faint: rgba(31, 29, 24, 0.42);
+  --t-ink-ghost: rgba(31, 29, 24, 0.10);
+  --t-accent: #4a6b3a;
+  --t-accent-deep: #2f4a24;
+  --t-accent-soft: rgba(74, 107, 58, 0.14);
+  --t-seal: #4a6b3a;
+  --t-highlight: #d8c870;
+  --t-verified: #4a6b3a;
+  --t-tape: rgba(190, 180, 150, 0.55);
+  --t-display-weight: 500;
+  --t-radius: 1px;
+  --t-anim-speed: 0.8;
+  --t-ornament-color: rgba(74, 107, 58, 0.6);
+}
+
+/* ─────────── theme: noir ─────────── */
+.theme-noir {
+  --t-bg: #18140e;
+  --t-paper: #221d14;
+  --t-paper-warm: #2a2418;
+  --t-paper-shadow: rgba(0, 0, 0, 0.55);
+  --t-paper-highlight: rgba(212, 168, 90, 0.10);
+  --t-ink: #ece4d2;
+  --t-ink-soft: #c8bea4;
+  --t-ink-faint: rgba(236, 228, 210, 0.42);
+  --t-ink-ghost: rgba(236, 228, 210, 0.12);
+  --t-accent: #d4a85a;
+  --t-accent-deep: #a07d34;
+  --t-accent-soft: rgba(212, 168, 90, 0.16);
+  --t-seal: #d4a85a;
+  --t-highlight: rgba(212, 168, 90, 0.32);
+  --t-verified: #9eb56c;
+  --t-tape: rgba(140, 110, 60, 0.55);
+  --t-display-weight: 500;
+  --t-radius: 1px;
+  --t-anim-speed: 0.6;
+  --t-ornament-color: rgba(212, 168, 90, 0.7);
+}
+
+/* ─────────── theme: gothic ─────────── */
+.theme-gothic {
+  --t-bg: #14111a;
+  --t-paper: #1d1825;
+  --t-paper-warm: #221d2c;
+  --t-paper-shadow: rgba(0, 0, 0, 0.6);
+  --t-paper-highlight: rgba(154, 134, 184, 0.10);
+  --t-ink: #e0dae8;
+  --t-ink-soft: #b8b0c6;
+  --t-ink-faint: rgba(224, 218, 232, 0.42);
+  --t-ink-ghost: rgba(224, 218, 232, 0.12);
+  --t-accent: #b89be0;
+  --t-accent-deep: #7e60a8;
+  --t-accent-soft: rgba(184, 155, 224, 0.16);
+  --t-seal: #b89be0;
+  --t-highlight: rgba(184, 155, 224, 0.32);
+  --t-verified: #9eb56c;
+  --t-tape: rgba(120, 100, 150, 0.45);
+  --t-display: 'Playfair Display', Georgia, serif;
+  --t-display-weight: 500;
+  --t-display-style: italic;
+  --t-radius: 1px;
+  --t-anim-speed: 0.4;
+  --t-ornament-color: rgba(184, 155, 224, 0.7);
+}
+
+/* ───────────────────────────────────────────────
+   shell + paper
+   ─────────────────────────────────────────────── */
+
+* { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; }
+body {
+  background: var(--t-bg);
+  color: var(--t-ink);
+  font-family: var(--t-body);
+  font-feature-settings: "kern", "liga", "onum";
+  font-size: 17px;
+  line-height: 1.6;
+  min-height: 100vh;
+  transition: background 800ms ease, color 800ms ease;
+}
+
+.app {
+  position: relative;
+  min-height: 100vh;
+  background: var(--t-bg);
+  transition: background 800ms ease, color 800ms ease;
+}
+
+/* paper grain over whole app */
+.grain {
+  position: fixed; inset: 0; pointer-events: none; z-index: 1;
+  background-image: var(--t-grain);
+  opacity: 0.5;
+  mix-blend-mode: multiply;
+}
+.theme-noir .grain, .theme-gothic .grain {
+  opacity: 0.45; mix-blend-mode: screen;
+}
+
+/* paper fibers: slightly larger texture */
+.app::before {
+  content: ''; position: fixed; inset: 0; pointer-events: none; z-index: 0;
+  background-image: var(--t-fibers);
+  opacity: 0.35;
+  mix-blend-mode: multiply;
+}
+.theme-noir.app::before, .theme-gothic.app::before {
+  mix-blend-mode: screen; opacity: 0.25;
+}
+
+.app > * { position: relative; z-index: 2; }
+
+/* ───────────────────────────────────────────────
+   chrome — paper tape header
+   ─────────────────────────────────────────────── */
+
+.chrome {
+  position: sticky; top: 0; z-index: 50;
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 16px 28px 14px;
+  background:
+    linear-gradient(180deg,
+      color-mix(in srgb, var(--t-paper) 92%, transparent) 0%,
+      color-mix(in srgb, var(--t-paper) 88%, transparent) 100%);
+  backdrop-filter: blur(6px);
+  border-bottom: 1px solid var(--t-ink-ghost);
+  font-family: var(--t-mono);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--t-ink-faint);
+  transition: background 800ms ease, border-color 800ms ease, color 800ms ease;
+}
+/* tape strip across the top */
+.chrome::before {
+  content: ''; position: absolute; left: 0; right: 0; top: 0; height: 4px;
+  background:
+    repeating-linear-gradient(90deg,
+      var(--t-tape) 0 14px,
+      color-mix(in srgb, var(--t-tape) 70%, var(--t-ink-soft)) 14px 16px,
+      var(--t-tape) 16px 28px);
+  opacity: 0.55;
+}
+/* ruled line below */
+.chrome::after {
+  content: ''; position: absolute; left: 0; right: 0; bottom: -1px;
+  height: 1px;
+  background:
+    repeating-linear-gradient(90deg,
+      var(--t-ink-faint) 0 6px, transparent 6px 10px);
+  opacity: 0.4;
+}
+
+.chrome .logo {
+  font-family: var(--t-display);
+  font-style: var(--t-display-style);
+  font-weight: var(--t-display-weight);
+  font-size: 26px;
+  letter-spacing: -0.01em;
+  text-transform: none;
+  color: var(--t-ink);
+  position: relative;
+  padding-right: 4px;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+.chrome .logo-dot {
+  display: inline-block;
+  width: 7px; height: 7px; border-radius: 50%;
+  background: var(--t-seal);
+  margin-left: 2px;
+  margin-bottom: 4px;
+  vertical-align: middle;
+  box-shadow: 0 1px 0 rgba(0,0,0,0.25), inset 0 1px 1px rgba(255,255,255,0.3);
+}
+.chrome .crumbs { display: flex; gap: 16px; align-items: center; }
+.chrome .crumb { transition: color 200ms; }
+.chrome .crumb.now { color: var(--t-ink); position: relative; }
+.chrome .crumb.now::after {
+  content: ''; position: absolute; left: 0; right: 0; bottom: -4px;
+  height: 1px; background: var(--t-seal);
+}
+.chrome .right { display: flex; gap: 18px; align-items: center; }
+
+/* byline = wax seal pip + label */
+.byline {
+  display: flex; align-items: center; gap: 8px;
+  font-family: var(--t-mono);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--t-ink-soft);
+}
+.byline-dot {
+  width: 10px; height: 10px; border-radius: 50%;
+  background: radial-gradient(circle at 35% 30%,
+    color-mix(in srgb, var(--t-seal) 80%, white) 0%,
+    var(--t-seal) 50%,
+    var(--t-accent-deep) 100%);
+  box-shadow:
+    0 1px 1px rgba(0,0,0,0.3),
+    inset 0 1px 1px rgba(255,255,255,0.35),
+    inset 0 -1px 1px rgba(0,0,0,0.25);
+  position: relative;
+}
+.byline-dot::after {
+  content: ''; position: absolute; inset: 2px;
+  border-radius: 50%;
+  border: 0.5px solid color-mix(in srgb, var(--t-seal) 50%, black);
+  opacity: 0.4;
+}
+
+/* ───────────────────────────────────────────────
+   stage
+   ─────────────────────────────────────────────── */
+
+.stage {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 56px 32px 96px;
+  position: relative;
+}
+
+/* ───────────────────────────────────────────────
+   typography
+   ─────────────────────────────────────────────── */
+
+.eyebrow {
+  font-family: var(--t-mono);
+  font-size: 10px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--t-ink-faint);
+  font-weight: 500;
+}
+.eyebrow.accent { color: var(--t-accent); }
+
+.h-display {
+  font-family: var(--t-display);
+  font-style: var(--t-display-style);
+  font-weight: var(--t-display-weight);
+  line-height: 1.05;
+  letter-spacing: -0.018em;
+  font-size: 76px;
+  color: var(--t-ink);
+  margin: 0;
+  text-wrap: pretty;
+}
+.h-display.smaller { font-size: 52px; line-height: 1.08; }
+.h-display.tiny { font-size: 36px; line-height: 1.1; }
+
+.body-prose {
+  font-family: var(--t-body);
+  font-size: 19px;
+  line-height: 1.6;
+  color: var(--t-ink-soft);
+  text-wrap: pretty;
+}
+
+.serif-italic {
+  font-family: var(--t-display);
+  font-style: italic;
+  font-weight: var(--t-display-weight);
+}
+
+.muted { color: var(--t-ink-faint); }
+
+/* drop cap */
+.drop-cap::first-letter {
+  font-family: var(--t-display);
+  font-style: var(--t-display-style);
+  font-weight: 700;
+  font-size: 4.4em;
+  float: left;
+  line-height: 0.82;
+  margin: 0.06em 0.08em 0 -0.04em;
+  color: var(--t-accent);
+}
+
+/* ───────────────────────────────────────────────
+   buttons — stamped impressions
+   ─────────────────────────────────────────────── */
+
+.btn {
+  display: inline-flex; align-items: center; gap: 10px;
+  padding: 12px 22px;
+  border: 1.5px solid var(--t-ink);
+  border-radius: var(--t-radius);
+  background: transparent;
+  font-family: var(--t-mono);
+  font-weight: 500;
+  font-size: 12px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--t-ink);
+  cursor: pointer;
+  transition: background 200ms, color 200ms, transform 80ms, box-shadow 200ms;
+  position: relative;
+}
+.btn:hover { background: var(--t-ink); color: var(--t-paper); }
+.btn:active { transform: translateY(1px); }
+
+.btn.primary {
+  background: var(--t-accent);
+  border-color: var(--t-accent);
+  color: var(--t-paper);
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, var(--t-accent) 60%, white),
+    inset 0 -1px 1px var(--t-accent-deep),
+    0 1px 0 var(--t-accent-deep);
+}
+.btn.primary:hover {
+  background: var(--t-accent-deep);
+  border-color: var(--t-accent-deep);
+}
+
+.btn.ghost {
+  border-style: dashed;
+  border-color: var(--t-ink-faint);
+  color: var(--t-ink-soft);
+}
+.btn.sm { padding: 8px 14px; font-size: 10px; letter-spacing: 0.16em; }
+
+/* stamped — looks like an ink stamp on paper */
+.btn.stamp {
+  font-family: var(--t-stamp);
+  font-size: 14px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  border: 2.5px solid var(--t-accent);
+  color: var(--t-accent);
+  background: transparent;
+  padding: 8px 18px;
+  transform: rotate(-1.5deg);
+  border-radius: 1px;
+  position: relative;
+}
+.btn.stamp::after {
+  content: ''; position: absolute; inset: -3px;
+  border: 2.5px solid transparent;
+  pointer-events: none;
+}
+.btn.stamp:hover { background: var(--t-accent-soft); transform: rotate(-1.5deg) translateY(-1px); }
+
+/* ───────────────────────────────────────────────
+   plates / cards — debossed paper
+   ─────────────────────────────────────────────── */
+
+.card {
+  background: var(--t-paper);
+  border: 1px solid var(--t-ink-ghost);
+  border-radius: var(--t-radius);
+  padding: 20px 22px;
+  transition: background 800ms, border-color 800ms, transform 200ms, box-shadow 200ms;
+  position: relative;
+}
+
+/* debossed plate — content "pressed in" */
+.plate {
+  background: var(--t-paper);
+  border: 1px solid var(--t-ink-ghost);
+  border-radius: var(--t-radius);
+  padding: 24px 26px;
+  position: relative;
+  box-shadow:
+    inset 0 1px 0 var(--t-paper-highlight),
+    inset 0 -1px 0 var(--t-paper-shadow),
+    0 0 0 1px color-mix(in srgb, var(--t-ink) 6%, transparent);
+}
+.plate.deep {
+  background: linear-gradient(180deg,
+    color-mix(in srgb, var(--t-paper) 96%, var(--t-paper-shadow)) 0%,
+    var(--t-paper) 50%,
+    var(--t-paper-warm) 100%);
+  box-shadow:
+    inset 0 2px 4px var(--t-paper-shadow),
+    inset 0 1px 0 var(--t-paper-highlight),
+    0 0 0 1px var(--t-ink-ghost);
+}
+
+/* embossed plate — content raised */
+.plate.raised {
+  background: var(--t-paper);
+  box-shadow:
+    inset 0 1px 0 var(--t-paper-highlight),
+    inset 0 -2px 3px var(--t-paper-shadow),
+    0 1px 0 var(--t-paper-highlight),
+    0 4px 12px var(--t-paper-shadow);
+}
+
+.card.outlined { border-color: var(--t-ink-soft); }
+.card.selected {
+  border-color: var(--t-accent);
+  box-shadow:
+    0 0 0 1px var(--t-accent),
+    0 8px 28px var(--t-accent-soft),
+    inset 0 1px 0 var(--t-paper-highlight);
+}
+.card.bare {
+  background: transparent;
+  border-style: dashed;
+  border-color: var(--t-ink-faint);
+}
+
+/* deckle edge — torn/uneven paper */
+.deckle {
+  position: relative;
+  background: var(--t-paper);
+  --deckle-mask: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='200' height='10' preserveAspectRatio='none'><path d='M 0 10 L 0 7 Q 8 4, 16 6 T 32 5 T 48 7 T 64 4 T 80 6 T 96 5 T 112 7 T 128 5 T 144 6 T 160 4 T 176 7 T 192 5 T 200 6 L 200 10 Z' fill='black'/></svg>");
+}
+.deckle::before, .deckle::after {
+  content: ''; position: absolute; left: 0; right: 0; height: 10px;
+  background: var(--t-paper);
+  -webkit-mask: var(--deckle-mask) repeat-x;
+          mask: var(--deckle-mask) repeat-x;
+}
+.deckle::before { top: -8px; transform: scaleY(-1); }
+.deckle::after  { bottom: -8px; }
+
+/* ───────────────────────────────────────────────
+   tags
+   ─────────────────────────────────────────────── */
+
+.tag {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 4px 10px;
+  font-family: var(--t-mono);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--t-ink-soft);
+  background: transparent;
+  border: 1px solid var(--t-ink-ghost);
+  border-radius: 999px;
+  cursor: pointer;
+  transition: all 200ms;
+}
+.tag:hover { border-color: var(--t-ink); }
+.tag.on {
+  background: var(--t-accent); color: var(--t-paper); border-color: var(--t-accent);
+  box-shadow: inset 0 1px 0 color-mix(in srgb, var(--t-accent) 60%, white);
+}
+
+/* ───────────────────────────────────────────────
+   inputs
+   ─────────────────────────────────────────────── */
+
+.input-stroke {
+  border: none;
+  border-bottom: 1.5px solid var(--t-ink);
+  background: transparent;
+  font-family: var(--t-display);
+  font-style: var(--t-display-style);
+  font-size: 28px;
+  color: var(--t-ink);
+  padding: 8px 2px;
+  width: 100%;
+  outline: none;
+}
+.input-stroke::placeholder { color: var(--t-ink-faint); }
+
+.textarea-prose {
+  width: 100%;
+  border: 1px solid var(--t-ink-ghost);
+  border-radius: var(--t-radius);
+  background: var(--t-paper);
+  padding: 18px 22px;
+  font-family: var(--t-body);
+  font-size: 18px;
+  line-height: 1.65;
+  color: var(--t-ink);
+  resize: none;
+  outline: none;
+  transition: border-color 200ms, background 800ms, box-shadow 200ms;
+  box-shadow: inset 0 1px 0 var(--t-paper-highlight), inset 0 -1px 0 var(--t-paper-shadow);
+}
+.textarea-prose:focus {
+  border-color: var(--t-accent);
+  box-shadow:
+    inset 0 1px 0 var(--t-paper-highlight),
+    inset 0 -1px 0 var(--t-paper-shadow),
+    0 0 0 3px var(--t-accent-soft);
+}
+
+/* ruled paper variant — for the artifact */
+.textarea-prose.ruled {
+  background:
+    repeating-linear-gradient(transparent 0 calc(1.65em - 1px),
+      var(--t-ink-ghost) calc(1.65em - 1px) 1.65em),
+    var(--t-paper);
+  background-attachment: local;
+  line-height: 1.65em;
+  padding-top: calc(18px + 2px);
+}
+
+/* ───────────────────────────────────────────────
+   ornaments / dividers
+   ─────────────────────────────────────────────── */
+
+.ornament { display: block; height: 16px; color: var(--t-ornament-color); }
+
+.divider-flourish {
+  display: flex; align-items: center; gap: 18px; margin: 28px 0;
+  color: var(--t-ornament-color);
+}
+.divider-flourish::before, .divider-flourish::after {
+  content: ''; flex: 1; height: 1px;
+  background:
+    repeating-linear-gradient(90deg, currentColor 0 4px, transparent 4px 7px);
+  opacity: 0.7;
+}
+.divider-flourish .ornament-glyph {
+  font-family: var(--t-display);
+  font-style: italic;
+  font-size: 16px;
+  color: var(--t-seal);
+  letter-spacing: 0.4em;
+  opacity: 0.85;
+}
+
+/* progress dots */
+.progress-dots { display: flex; gap: 6px; align-items: center; }
+.progress-dots .d {
+  width: 7px; height: 7px; border-radius: 50%;
+  background: var(--t-ink-ghost);
+  transition: background 200ms, transform 200ms;
+}
+.progress-dots .d.on {
+  background: var(--t-accent);
+  box-shadow: 0 0 0 3px var(--t-accent-soft);
+}
+
+/* ───────────────────────────────────────────────
+   theme slider — brass dial in chrome
+   ─────────────────────────────────────────────── */
+
+.theme-slider {
+  display: flex; align-items: center; gap: 10px;
+  padding: 6px 12px;
+  border: 1px solid var(--t-ink-ghost);
+  border-radius: 999px;
+  background: var(--t-paper);
+  box-shadow: inset 0 1px 0 var(--t-paper-highlight), inset 0 -1px 0 var(--t-paper-shadow);
+}
+.theme-slider .label {
+  font-family: var(--t-mono); font-size: 9px; letter-spacing: 0.18em;
+  color: var(--t-ink-faint); text-transform: uppercase;
+}
+.theme-slider .track {
+  position: relative; width: 168px; height: 18px;
+  display: flex; align-items: center;
+}
+.theme-slider .track::before {
+  content: ''; position: absolute; left: 6px; right: 6px; height: 2px;
+  background: linear-gradient(90deg, #d34860, #8b2418, #4a6b3a, #d4a85a, #b89be0);
+  border-radius: 2px;
+  opacity: 0.85;
+}
+.theme-slider .pip {
+  flex: 1; display: flex; justify-content: center; position: relative; z-index: 1;
+  cursor: pointer; background: none; border: none; padding: 0;
+}
+.theme-slider .pip span {
+  width: 10px; height: 10px; border-radius: 50%;
+  background: var(--t-paper);
+  border: 1.5px solid var(--t-ink-faint);
+  transition: all 200ms;
+}
+.theme-slider .pip:hover span { transform: scale(1.2); border-color: var(--t-ink); }
+.theme-slider .pip.on span {
+  background: var(--t-accent); border-color: var(--t-accent);
+  transform: scale(1.4);
+  box-shadow: 0 0 0 3px var(--t-accent-soft), inset 0 1px 0 rgba(255,255,255,0.35);
+}
+
+/* ───────────────────────────────────────────────
+   highlight + verbatim mark
+   ─────────────────────────────────────────────── */
+
+.hl {
+  background: linear-gradient(transparent 60%, var(--t-highlight) 60% 90%, transparent 90%);
+  padding: 0 2px;
+}
+
+/* hover trace popover */
+.trace-line {
+  position: relative; cursor: help;
+  transition: background 200ms;
+  padding: 0 2px; margin: 0 -2px;
+  border-radius: 1px;
+}
+.trace-line:hover { background: var(--t-accent-soft); }
+.trace-line::after {
+  content: ''; position: absolute; left: 2px; right: 2px; bottom: -1px;
+  height: 1px;
+  background: var(--t-verified);
+  opacity: 0.22;
+}
+
+.trace-pop {
+  position: fixed; z-index: 80; width: 340px;
+  background: var(--t-paper);
+  border: 1px solid var(--t-ink);
+  border-radius: var(--t-radius);
+  padding: 16px 18px;
+  font-family: var(--t-body);
+  font-size: 13px; line-height: 1.55;
+  color: var(--t-ink-soft);
+  box-shadow:
+    0 1px 0 var(--t-paper-highlight),
+    0 14px 44px rgba(0,0,0,0.20),
+    inset 0 1px 0 var(--t-paper-highlight);
+  pointer-events: none;
+}
+
+/* ───────────────────────────────────────────────
+   postal motifs
+   ─────────────────────────────────────────────── */
+
+/* postage-stamp frame */
+.postage {
+  position: relative;
+  background: var(--t-paper);
+  padding: 14px 16px;
+  --stamp-mask: radial-gradient(circle at 4px 4px, transparent 3px, black 3.5px);
+  --stamp-mask-size: 8px 8px;
+  border-radius: 0;
+  box-shadow:
+    inset 0 1px 0 var(--t-paper-highlight),
+    0 2px 6px var(--t-paper-shadow);
+}
+.postage::before {
+  content: ''; position: absolute; inset: -4px;
+  background: var(--t-paper);
+  -webkit-mask:
+    radial-gradient(circle at 0 0, transparent 4px, black 4.5px) 0 0 / 8px 8px,
+    radial-gradient(circle at 100% 0, transparent 4px, black 4.5px) 0 0 / 8px 8px;
+  z-index: -1;
+}
+/* simpler: use perforated edge via repeating mask */
+.postage-edge {
+  --d: 6px;
+  -webkit-mask:
+    radial-gradient(circle at var(--d) var(--d), transparent calc(var(--d) - 1.5px), black calc(var(--d) - 1px)) 0 0 / calc(var(--d) * 2) calc(var(--d) * 2);
+          mask:
+    radial-gradient(circle at var(--d) var(--d), transparent calc(var(--d) - 1.5px), black calc(var(--d) - 1px)) 0 0 / calc(var(--d) * 2) calc(var(--d) * 2);
+}
+
+/* postmark — circular ink stamp, slightly tilted */
+.postmark {
+  display: inline-flex; flex-direction: column; align-items: center; justify-content: center;
+  width: 110px; height: 110px;
+  border: 2.5px solid var(--t-accent);
+  border-radius: 50%;
+  color: var(--t-accent);
+  font-family: var(--t-stamp);
+  text-transform: uppercase;
+  text-align: center;
+  letter-spacing: 0.06em;
+  padding: 8px;
+  transform: rotate(-6deg);
+  position: relative;
+  background: transparent;
+  opacity: 0.92;
+}
+.postmark::before, .postmark::after {
+  content: ''; position: absolute; left: 6px; right: 6px;
+  height: 1.5px; background: var(--t-accent);
+}
+.postmark::before { top: 24px; }
+.postmark::after { bottom: 24px; }
+.postmark .pm-top { font-size: 9px; letter-spacing: 0.16em; }
+.postmark .pm-mid { font-size: 16px; font-weight: 700; line-height: 1; margin: 4px 0; }
+.postmark .pm-bot { font-size: 9px; letter-spacing: 0.16em; }
+
+/* wax seal */
+.seal {
+  position: relative;
+  width: 64px; height: 64px;
+  border-radius: 50%;
+  background:
+    radial-gradient(circle at 30% 28%,
+      color-mix(in srgb, var(--t-seal) 70%, white) 0%,
+      var(--t-seal) 35%,
+      var(--t-accent-deep) 90%);
+  display: flex; align-items: center; justify-content: center;
+  box-shadow:
+    0 1px 1px rgba(0,0,0,0.3),
+    0 4px 10px rgba(0,0,0,0.18),
+    inset 0 2px 3px rgba(255,255,255,0.32),
+    inset 0 -3px 4px rgba(0,0,0,0.32);
+}
+.seal::before {
+  content: ''; position: absolute; inset: -4px -4px -4px -4px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 50% 50%, transparent 60%, var(--t-seal) 62%, transparent 75%);
+  filter: blur(0.6px);
+  opacity: 0.55;
+  z-index: -1;
+  /* drips */
+  clip-path: polygon(
+    0% 50%, 8% 30%, 18% 40%, 30% 18%, 42% 32%, 50% 12%,
+    60% 28%, 72% 18%, 82% 36%, 92% 26%, 100% 50%,
+    96% 70%, 88% 88%, 76% 76%, 60% 92%, 50% 80%, 38% 96%, 24% 78%, 12% 90%, 4% 70%
+  );
+}
+.seal-glyph {
+  font-family: var(--t-display);
+  font-style: italic;
+  font-weight: 700;
+  font-size: 24px;
+  color: color-mix(in srgb, var(--t-seal) 30%, black);
+  text-shadow: 0 1px 0 rgba(255,255,255,0.18);
+  user-select: none;
+}
+
+/* corner postmark — small, top-right of artifact */
+.corner-stamp {
+  position: absolute; top: 18px; right: 18px;
+  transform: rotate(8deg);
+}
+
+/* ───────────────────────────────────────────────
+   tape / scotch
+   ─────────────────────────────────────────────── */
+
+.tape {
+  position: absolute;
+  background: var(--t-tape);
+  height: 24px; width: 80px;
+  opacity: 0.7;
+  box-shadow: inset 0 1px 1px rgba(255,255,255,0.35), inset 0 -1px 1px rgba(0,0,0,0.18);
+  border-left: 1px dashed rgba(0,0,0,0.18);
+  border-right: 1px dashed rgba(0,0,0,0.18);
+  pointer-events: none;
+}
+.tape.tl { top: -10px; left: 24px; transform: rotate(-3deg); }
+.tape.tr { top: -10px; right: 24px; transform: rotate(2deg); }
+
+/* ───────────────────────────────────────────────
+   ambient motion (per theme)
+   ─────────────────────────────────────────────── */
+
+@keyframes float-y { 0%, 100% { transform: translateY(0); } 50% { transform: translateY(-6px); } }
+@keyframes pulse-fade { 0%, 100% { opacity: 0.85; } 50% { opacity: 1; } }
+@keyframes sway { 0%, 100% { transform: rotate(-1deg); } 50% { transform: rotate(1deg); } }
+
+.theme-cute   .anim-mascot { animation: float-y 4s ease-in-out infinite, sway 6s ease-in-out infinite; transform-origin: center bottom; }
+.theme-warm   .anim-mascot { animation: float-y 6s ease-in-out infinite; }
+.theme-quiet  .anim-mascot { animation: float-y 9s ease-in-out infinite; }
+.theme-noir   .anim-mascot { animation: pulse-fade 5s ease-in-out infinite; }
+.theme-gothic .anim-mascot { animation: pulse-fade 7s ease-in-out infinite; }
+
+/* ───────────────────────────────────────────────
+   utilities
+   ─────────────────────────────────────────────── */
+
+.no-scrollbar::-webkit-scrollbar { display: none; }
+.no-scrollbar { scrollbar-width: none; }
+
+/* keep transitions calm but coordinated */
+.app, .chrome, .card, .plate, .btn, .tag, .textarea-prose {
+  transition-property: background, color, border-color, box-shadow;
+  transition-duration: 800ms;
+}
+
+/* ───────────────────────────────────────────────
+   modal / overlay (used by download/save/share)
+   ─────────────────────────────────────────────── */
+
+.scrim {
+  position: fixed; inset: 0; z-index: 200;
+  background:
+    radial-gradient(ellipse at center, color-mix(in srgb, var(--t-ink) 25%, transparent) 0%, color-mix(in srgb, var(--t-ink) 70%, transparent) 100%);
+  backdrop-filter: blur(6px);
+  display: flex; align-items: center; justify-content: center;
+  animation: fadein 240ms ease;
+  padding: 24px;
+  overflow-y: auto;
+}
+@keyframes fadein { from { opacity: 0; transform: translateY(4px); } to { opacity: 1; transform: none; } }
+@keyframes blink { 50% { opacity: 0; } }
+@keyframes stamp-in { 0% { transform: scale(1.6) rotate(-12deg); opacity: 0; } 100% { transform: scale(1) rotate(-6deg); opacity: 0.92; } }
+
+.dialog {
+  background: var(--t-paper);
+  border: 1px solid var(--t-ink);
+  border-radius: var(--t-radius);
+  padding: 36px 40px;
+  max-width: 560px;
+  width: 100%;
+  position: relative;
+  box-shadow:
+    0 1px 0 var(--t-paper-highlight),
+    0 24px 80px rgba(0,0,0,0.32),
+    inset 0 1px 0 var(--t-paper-highlight);
+  max-height: calc(100vh - 48px);
+  overflow-y: auto;
+}
+.dialog .close {
+  position: absolute; top: 14px; right: 14px;
+  background: none; border: none; cursor: pointer;
+  font-family: var(--t-mono); font-size: 11px; color: var(--t-ink-faint);
+  letter-spacing: 0.14em; text-transform: uppercase;
+  padding: 4px 8px;
+}
+.dialog .close:hover { color: var(--t-ink); }

--- a/lib/demo.ts
+++ b/lib/demo.ts
@@ -1,0 +1,141 @@
+// Eulogy demo seed — Tomas / Wren / quiet-theme. Lifted verbatim from
+// docs/design/hifi/screens-1.jsx. Stub routes in `app/api/*` slice this;
+// sprint-2 backend swaps the bodies for real Sonnet/Haiku calls without
+// changing the request/response shape components consume.
+
+export interface DemoInterviewTurn {
+  q: string;
+  a: string;
+  mood: "listening" | "curious" | "moved" | "sad" | "hopeful" | "silence";
+}
+
+export interface DemoSpineCandidate {
+  text: string;
+  source_turn_id: string;
+  source_label: string;
+}
+
+export interface DemoStructureMovement {
+  label: string;
+  sub: string;
+}
+
+export interface DemoDraftLine {
+  text: string;
+  verified: boolean;
+  src: string | null;
+  flag?: "cliche";
+}
+
+export interface DemoScript {
+  recipient: string;
+  occasion: string;
+  form: "letter" | "poem";
+  guide_id: string;
+  mascot_id: "wren" | "pip" | "cassio";
+  theme: "cute" | "warm" | "quiet" | "noir" | "gothic";
+  interview: DemoInterviewTurn[];
+  spineCandidates: DemoSpineCandidate[];
+  structure: DemoStructureMovement[];
+  draft: DemoDraftLine[];
+}
+
+export const SCRIPT: DemoScript = {
+  recipient: "my grandfather, Tomas",
+  occasion: "eulogy",
+  form: "letter",
+  guide_id: "documentarian",
+  mascot_id: "wren",
+  theme: "quiet",
+
+  interview: [
+    {
+      q: "What did he always say when he answered the phone?",
+      a: "He'd say 'Pronto, who's calling my house?' — like he was offended you'd dare. He wasn't.",
+      mood: "curious",
+    },
+    {
+      q: "What's a thing he did that nobody else would have done?",
+      a: "He kept a notebook in his coat pocket. Wrote down strangers' names on the bus so he could greet them next time.",
+      mood: "moved",
+    },
+    {
+      q: "When you picture his hands — what are they doing?",
+      a: "Fixing the radio. Always the same radio. Tuning the dial like it was a violin string.",
+      mood: "listening",
+    },
+    {
+      q: "Was there a phrase only he used?",
+      a: "'The world is wide and the kitchen is small.' He'd say it before any meal that took effort.",
+      mood: "moved",
+    },
+    {
+      q: "What didn't you get to say?",
+      a: "That I learned the radio thing. I tune the dial the same way now. I never told him.",
+      mood: "sad",
+    },
+  ],
+
+  spineCandidates: [
+    {
+      text: "tuning the dial like it was a violin string",
+      source_turn_id: "q3",
+      source_label: "q3 · his hands",
+    },
+    {
+      text: "the world is wide and the kitchen is small",
+      source_turn_id: "q4",
+      source_label: "q4 · his phrase",
+    },
+    {
+      text: "I tune the dial the same way now",
+      source_turn_id: "q5",
+      source_label: "q5 · what you didn't say",
+    },
+  ],
+
+  structure: [
+    { label: "memory", sub: "the radio, his hands" },
+    { label: "phrase", sub: '"world is wide…"' },
+    { label: "inheritance", sub: "the dial · the silence · what wasn't said" },
+  ],
+
+  draft: [
+    {
+      text: "Tomas kept a notebook in his coat pocket.",
+      verified: true,
+      src: "q2",
+    },
+    {
+      text: "He wrote down strangers' names so he could greet them next time.",
+      verified: true,
+      src: "q2",
+    },
+    {
+      text: "His hands tuned the radio dial like it was a violin string.",
+      verified: true,
+      src: "q3",
+    },
+    {
+      text: "He used to say: the world is wide and the kitchen is small.",
+      verified: true,
+      src: "q4",
+    },
+    {
+      text: "He was forever in our hearts.",
+      verified: false,
+      src: null,
+      flag: "cliche",
+    },
+    {
+      text: "I tune the dial the same way now.",
+      verified: true,
+      src: "q5",
+    },
+    {
+      text: "I never told him.",
+      verified: true,
+      src: "q5",
+    },
+  ],
+};

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -1,0 +1,139 @@
+"use client";
+
+import { useEffect, useReducer } from "react";
+import type { Emotion } from "@/components/mascots";
+import type { Form, Theme } from "@/lib/types/session";
+
+export type Step =
+  | "moment"
+  | "guide"
+  | "interview"
+  | "spine"
+  | "drafting"
+  | "render";
+
+export type ModalKind =
+  | "createguide"
+  | "download"
+  | "save"
+  | "share"
+  | "startover"
+  | "imagecard"
+  | "reel"
+  | null;
+
+// Slice of `Session` accumulated as the user moves through the flow. The
+// canonical `Session` (from `@/lib/types/session`) is constructed at render
+// time when all required fields are present.
+export interface DraftSession {
+  recipient: string;
+  occasion: string;
+  form: Form | null;
+  guide_id: string | null;
+}
+
+export interface AppState {
+  step: Step;
+  theme: Theme;
+  emotion: Emotion;
+  modal: ModalKind;
+  draft: DraftSession;
+}
+
+export type Action =
+  | { type: "set_step"; step: Step }
+  | { type: "next_step" }
+  | { type: "set_theme"; theme: Theme }
+  | { type: "set_emotion"; emotion: Emotion }
+  | { type: "set_modal"; modal: ModalKind }
+  | { type: "patch_draft"; patch: Partial<DraftSession> }
+  | { type: "reset" };
+
+const STEPS: readonly Step[] = [
+  "moment",
+  "guide",
+  "interview",
+  "spine",
+  "drafting",
+  "render",
+] as const;
+
+export const INITIAL_STATE: AppState = {
+  step: "moment",
+  theme: "quiet",
+  emotion: "listening",
+  modal: null,
+  draft: {
+    recipient: "",
+    occasion: "",
+    form: null,
+    guide_id: null,
+  },
+};
+
+export function reducer(state: AppState, action: Action): AppState {
+  switch (action.type) {
+    case "set_step":
+      return { ...state, step: action.step };
+    case "next_step": {
+      const i = STEPS.indexOf(state.step);
+      const next = STEPS[i + 1] ?? "moment";
+      return { ...state, step: next };
+    }
+    case "set_theme":
+      return { ...state, theme: action.theme };
+    case "set_emotion":
+      return { ...state, emotion: action.emotion };
+    case "set_modal":
+      return { ...state, modal: action.modal };
+    case "patch_draft":
+      return { ...state, draft: { ...state.draft, ...action.patch } };
+    case "reset":
+      return INITIAL_STATE;
+  }
+}
+
+const STORAGE_KEY = "mean_it_app_state_v1";
+
+function loadInitial(): AppState {
+  if (typeof window === "undefined") return INITIAL_STATE;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return INITIAL_STATE;
+    const parsed = JSON.parse(raw) as Partial<AppState>;
+    return {
+      ...INITIAL_STATE,
+      ...parsed,
+      draft: { ...INITIAL_STATE.draft, ...(parsed.draft ?? {}) },
+    };
+  } catch {
+    return INITIAL_STATE;
+  }
+}
+
+export function useAppStore() {
+  const [state, dispatch] = useReducer(reducer, INITIAL_STATE, loadInitial);
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    try {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+    } catch {
+      // localStorage full or unavailable — drop silently.
+    }
+  }, [state]);
+  return [state, dispatch] as const;
+}
+
+// Action constructors for ergonomic dispatch at call sites.
+export const actions = {
+  setStep: (step: Step): Action => ({ type: "set_step", step }),
+  nextStep: (): Action => ({ type: "next_step" }),
+  setTheme: (theme: Theme): Action => ({ type: "set_theme", theme }),
+  setEmotion: (emotion: Emotion): Action => ({ type: "set_emotion", emotion }),
+  setModal: (modal: ModalKind): Action => ({ type: "set_modal", modal }),
+  patchDraft: (patch: Partial<DraftSession>): Action => ({
+    type: "patch_draft",
+    patch,
+  }),
+  reset: (): Action => ({ type: "reset" }),
+};

--- a/scratch.py
+++ b/scratch.py
@@ -1,0 +1,21 @@
+import os
+
+with open(r'docs\design\hifi\theme.css', 'r', encoding='utf-8') as f:
+    content = f.read()
+
+replacements = {
+    "'Playfair Display'": "var(--font-playfair-display)",
+    "'EB Garamond'": "var(--font-eb-garamond)",
+    "'JetBrains Mono'": "var(--font-jetbrains-mono)",
+    "'Special Elite'": "var(--font-special-elite)",
+    "'Caveat'": "var(--font-caveat)",
+    "'Fraunces'": "var(--font-fraunces)"
+}
+
+for k, v in replacements.items():
+    content = content.replace(k, v)
+
+final_content = "@tailwind base;\n@tailwind components;\n@tailwind utilities;\n\n" + content
+
+with open(r'app\globals.css', 'w', encoding='utf-8') as f:
+    f.write(final_content)

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -4,36 +4,9 @@ const config: Config = {
   content: ["./app/**/*.{ts,tsx}", "./components/**/*.{ts,tsx}"],
   theme: {
     extend: {
-      fontFamily: {
-        serif: ["Lora", "Georgia", "serif"],
-        sans: ["DM Sans", "system-ui", "sans-serif"],
-        "serif-edge": ["Playfair Display", "Georgia", "serif"],
-        "sans-edge": ["Space Grotesk", "system-ui", "sans-serif"],
-      },
-      colors: {
-        // Warm static palette (Figma spec)
-        warm: {
-          50: "#FAF8F4",
-          100: "#F2EDE4",
-          200: "#E5DDD0",
-          300: "#D3D1C7",
-          400: "#EF9F27",
-          500: "#D98C1A",
-          600: "#BA7517",
-        },
-        // CSS-var-backed runtime tokens
-        bg: "var(--bg)",
-        surface: "var(--surface)",
-        border: "var(--border)",
-        "text-primary": "var(--text-primary)",
-        "text-muted": "var(--text-muted)",
-        accent: "var(--accent)",
-        "accent-soft": "var(--accent-soft)",
-      },
       borderRadius: {
         chip: "12px",
         card: "16px",
-        btn: "var(--radius-btn)",
       },
     },
   },


### PR DESCRIPTION
## Closes #2 #20 #21 #22

Design refresh — letterpress / stationery identity. Wholesale UI rewrite from `docs/design/hifi/`. **Three contributors working in parallel on a single branch; this PR is the integration target.** Marked draft until everyone's slice has landed.

### What's landed (Frex22 / Aakash)
- `docs/design/` — full Claude Design package (`4b1ae59`)
- Mascot system — Wren / Pip / Cassio × 6 emotions, ink-line SVG (`48b959e`)
- App store — `lib/store.ts` reducer + persistence; reads canonical `Session` (`48b959e`)
- Demo seed — `lib/demo.ts` Tomas eulogy SCRIPT (`de93cef`)
- Spine + Render screens (`de93cef`)
- `/api/spine` stub (`de93cef`)
- Tests + Vitest JSX-runtime fix (`7e8963a`)
- **Cleanup** of parallel types + old components — placeholder `app/page.tsx` (`b1c69b6`)

### What's landed (PruthviVKadam)
- Visual foundation: `app/globals.css` (theme.css drop), `next/font` for 5 typefaces, tailwind trim (`154cf08`)

### Expected on this PR (still landing)
- `@PruthviVKadam` — Chrome, ThemeSlider, SettingsModal, PickMoment, GuidePicker, full `app/page.tsx` wiring (overwrites my placeholder)
- `@d3v07` (optional) — `lib/byo-key.ts` + `lib/byo-key/server.ts`, Interview + Drafting screens

### Issue closure mapping
| Issue | What closes it |
|---|---|
| **#2** | PickMoment + GuidePicker (Pruthvi, pending) · theme tokens via `theme.css` (landed) · canonical `Session` persistence via `lib/store.ts` (landed) |
| **#20** | `b1c69b6` deletes parallel `Session` + `GuideStub`; all consumers now read `@/lib/types/session` |
| **#21** | `next/font` (landed) · CSS-var theme system, no inline `#FF69B4` · `router.push` replaces `window.location.href` (Pruthvi's pending Chrome) |
| **#22** | `tests/lib/store.test.ts` + `tests/components/Mascot.test.ts` cover the canonical replacements; the libs originally targeted (`lib/theme.ts`, `lib/session.ts`) were removed in `b1c69b6` and equivalent coverage shifted to the new pure modules |

### Notes
- `app/page.tsx` is a **placeholder step-router** — Pruthvi's wave 3 commit will overwrite it with the full Chrome + all 6 screens.
- Reel composer (`docs/design/hifi/reel.jsx`) is reference-only; backend port lands later in `d3v07`'s #10.
- No real Claude calls in this branch — stub routes return SCRIPT-shaped data with `X-Mean-It-Stub: 1`. Sprint-2 swaps the bodies for real Sonnet/Haiku calls without changing the request/response contract.
- Cross-lane edits authorized for this refresh (per the team).

### Gates (current state on the branch)
- `tsc --noEmit` ✓
- `vitest run` — 72 / 72 across 9 test files ✓
- `next lint` ✓