### PR TITLE
feat: real interviewer + spine + Interview screen (refs #26)

### DIFF
--- a/app/api/interview/turn/route.ts
+++ b/app/api/interview/turn/route.ts
@@ -1,92 +1,334 @@
+import path from "node:path";
+import type Anthropic from "@anthropic-ai/sdk";
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
+import { anthropicForKey } from "@/lib/anthropic";
 import { keyOriginTag, readKey } from "@/lib/byo-key/server";
+import { loadBuiltInGuides } from "@/lib/guides/loader";
+import { assemblePrompt } from "@/lib/interview/assemble-prompt";
 import { log } from "@/lib/logger";
+import { verbatimOnly } from "@/lib/spine/validate";
+import { FormSchema, ThemeSchema } from "@/lib/types/session";
 
+// Edge would be ideal for streaming, but `loadBuiltInGuides` reads from
+// disk via `node:fs`. Building a const-bundle of guides is out of scope
+// for this PR — we accept Node runtime for now.
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-// Canned script for the v1 stub. Real Sonnet 4.6 interviewer ships in #6.
-// Each entry is a question + an optional meta-note in the guide's voice.
-const SCRIPT: ReadonlyArray<{ question: string; meta?: string }> = [
+// ─────────── Schemas ───────────
+
+const GUIDE_ID = z
+  .string()
+  .regex(/^[A-Za-z0-9_-]{3,64}$/, "guide_id must be 3-64 chars [A-Za-z0-9_-]");
+
+const TurnSchema = z.object({
+  id: z.string(),
+  role: z.enum(["guide", "user"]),
+  text: z.string().max(8000),
+});
+
+// Canonical shape per #6 / #26.
+const Canonical = z.object({
+  session: z.object({
+    recipient: z.string().min(1),
+    occasion: z.string().min(1),
+    form: FormSchema,
+  }),
+  guide_id: GUIDE_ID,
+  turns: z.array(TurnSchema).max(40),
+  theme: ThemeSchema.optional(),
+});
+
+// Legacy stub shape preserved during transition. Existing dev callers
+// (and the d3v07 stub tests) use this.
+const Legacy = z.object({
+  guide_id: GUIDE_ID,
+  turn_index: z.number().int().min(0).default(0),
+  user_text: z.string().max(8000).optional(),
+  theme: ThemeSchema.optional(),
+});
+
+type CanonicalBody = z.infer<typeof Canonical>;
+type LegacyBody = z.infer<typeof Legacy>;
+
+// ─────────── Stub fallback ───────────
+
+const STUB_SCRIPT: ReadonlyArray<{ question: string; meta?: string }> = [
   {
     question: "What's a smell that means home, when you think of her?",
     meta: "the best small details are ones only one person knew.",
   },
-  {
-    question: "What did she always say when she answered the phone?",
-  },
+  { question: "What did she always say when she answered the phone?" },
   {
     question: "What's a thing she did that nobody else would have done?",
     meta: "specifics over abstractions — a Tuesday, not 'her presence'.",
   },
-  {
-    question: "What hands do you remember? How did they hold things?",
-  },
+  { question: "What hands do you remember? How did they hold things?" },
   { question: "What didn't you get to say?" },
 ];
 
-const GUIDE_ID = z.string().regex(/^[A-Za-z0-9_-]{3,64}$/, "guide_id must be 3-64 chars [A-Za-z0-9_-]");
+function stubExtractCandidatePhrases(text: string): string[] {
+  const cleaned = text.replace(/\s+/g, " ").trim();
+  if (!cleaned) return [];
+  const sentences = cleaned.split(/[.!?]\s+/).filter((s) => s.length > 0);
+  return sentences
+    .filter((s) => {
+      const wc = s.split(" ").length;
+      return wc >= 3 && wc <= 12;
+    })
+    .slice(0, 2);
+}
 
-const Body = z.object({
-  guide_id: GUIDE_ID,
-  turn_index: z.number().int().min(0).default(0),
-  user_text: z.string().max(8000).optional(),
-  theme: z.enum(["cute", "warm", "quiet", "noir", "gothic"]).optional(),
-});
+// ─────────── Memoized guide load ───────────
 
-export async function POST(req: NextRequest) {
+let guidesCache: ReturnType<typeof loadBuiltInGuides> | null = null;
+function getBuiltInGuides() {
+  if (!guidesCache) {
+    guidesCache = loadBuiltInGuides(
+      path.join(process.cwd(), "prompts", "guides"),
+    );
+  }
+  return guidesCache;
+}
+
+// ─────────── SSE helpers ───────────
+
+const ENCODER = new TextEncoder();
+function sseFrame(event: string, data: unknown): Uint8Array {
+  return ENCODER.encode(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`);
+}
+
+// ─────────── POST handler ───────────
+
+export async function POST(req: NextRequest): Promise<Response> {
   const requestId = req.headers.get("x-request-id") ?? crypto.randomUUID();
   const keyOrigin = keyOriginTag(req);
   const key = readKey(req);
 
-  let body: unknown;
+  let raw: unknown;
   try {
-    body = await req.json();
+    raw = await req.json();
   } catch {
-    return NextResponse.json({ error: "expected JSON body" }, { status: 400 });
-  }
-
-  const parsed = Body.safeParse(body);
-  if (!parsed.success) {
     return NextResponse.json(
-      { error: "invalid body", issues: parsed.error.flatten() },
+      { error: "expected JSON body" },
       { status: 400 },
     );
   }
 
-  const { guide_id, turn_index } = parsed.data;
-  const i = Math.min(turn_index, SCRIPT.length - 1);
-  const slot = SCRIPT[i]!;
-  const phrasesHeld = parsed.data.user_text
-    ? extractCandidatePhrases(parsed.data.user_text)
-    : [];
+  const canonical = Canonical.safeParse(raw);
+  const legacy = Legacy.safeParse(raw);
+
+  // Stub mode: no key, OR caller used the legacy (non-canonical) shape.
+  // Both keep dev DX with no API key required.
+  if (keyOrigin === "missing" || !key || !canonical.success) {
+    if (canonical.success) return stubResponse(requestId, keyOrigin, canonical.data);
+    if (legacy.success) return stubResponse(requestId, keyOrigin, legacy.data);
+    return NextResponse.json(
+      {
+        error: "invalid body",
+        issues: legacy.error.flatten(),
+      },
+      { status: 400 },
+    );
+  }
+
+  // Real mode: canonical shape + a real key (BYO or env).
+  return realResponse(requestId, keyOrigin, canonical.data, key);
+}
+
+// ─────────── Stub response ───────────
+
+function stubResponse(
+  requestId: string,
+  keyOrigin: "byo" | "env" | "missing",
+  parsed: CanonicalBody | LegacyBody,
+): Response {
+  let guide_id: string;
+  let turn_index: number;
+  let user_text: string | undefined;
+
+  if ("session" in parsed) {
+    guide_id = parsed.guide_id;
+    turn_index = parsed.turns.filter((t) => t.role === "guide").length;
+    const lastUser = [...parsed.turns].reverse().find((t) => t.role === "user");
+    user_text = lastUser?.text;
+  } else {
+    guide_id = parsed.guide_id;
+    turn_index = parsed.turn_index;
+    user_text = parsed.user_text;
+  }
+
+  const i = Math.min(turn_index, STUB_SCRIPT.length - 1);
+  const slot = STUB_SCRIPT[i]!;
+  const phrasesHeld = user_text ? stubExtractCandidatePhrases(user_text) : [];
 
   log.info("interview.turn.stub", {
     request_id: requestId,
     guide_id,
     turn_index: i,
     key_origin: keyOrigin,
-    has_key: Boolean(key),
+    has_key: keyOrigin !== "missing",
   });
 
   return NextResponse.json({
     stub: true,
     turn_index: i,
-    is_last: i === SCRIPT.length - 1,
+    is_last: i === STUB_SCRIPT.length - 1,
     question: slot.question,
     meta: slot.meta ?? null,
     phrases_held: phrasesHeld,
   });
 }
 
-// Pull short verbatim runs from the user's turn so the holding-pane in the
-// interview UI has something to show. Real spine extractor (#6) replaces this.
-function extractCandidatePhrases(text: string): string[] {
-  const cleaned = text.replace(/\s+/g, " ").trim();
-  if (!cleaned) return [];
-  const sentences = cleaned.split(/[.!?]\s+/).filter((s) => s.length > 0);
-  return sentences
-    .filter((s) => s.split(" ").length >= 3 && s.split(" ").length <= 12)
-    .slice(0, 2);
+// ─────────── Real (Sonnet 4.6) response ───────────
+
+async function realResponse(
+  requestId: string,
+  keyOrigin: "byo" | "env",
+  body: CanonicalBody,
+  key: string,
+): Promise<Response> {
+  const { session, guide_id, turns, theme } = body;
+
+  const guide = getBuiltInGuides().find((g) => g.id === guide_id);
+  if (!guide) {
+    return NextResponse.json(
+      { error: `unknown guide_id: ${guide_id}` },
+      { status: 404 },
+    );
+  }
+
+  const systemPrompt = assemblePrompt({
+    guide,
+    recipient: session.recipient,
+    occasion: session.occasion,
+    form: session.form,
+    theme,
+  });
+
+  // Map canonical turns → Anthropic message params. Empty turns means
+  // first call — bootstrap with a synthetic user message so Sonnet
+  // produces the opening greeting + first question per its system prompt.
+  const messages: Anthropic.MessageParam[] =
+    turns.length === 0
+      ? [{ role: "user", content: "Please begin the interview." }]
+      : turns.map((t) => ({
+          role: t.role === "guide" ? ("assistant" as const) : ("user" as const),
+          content: t.text,
+        }));
+
+  const userTurnsText = turns
+    .filter((t) => t.role === "user")
+    .map((t) => t.text);
+
+  log.info("interview.turn.start", {
+    request_id: requestId,
+    guide_id,
+    theme: theme ?? "warm",
+    turn_count: turns.length,
+    key_origin: keyOrigin,
+  });
+
+  const stream = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      try {
+        const client = anthropicForKey(key);
+
+        const tools: Anthropic.Tool[] = [
+          {
+            name: "record_phrases_held",
+            description:
+              "Record 1-3 verbatim substrings from the user's recent turns that you are holding onto as candidate spine phrases. Each phrase MUST be an exact substring of one of the user's turns — never paraphrase, never summarize. Use this when something specific in the user's answer struck you.",
+            input_schema: {
+              type: "object" as const,
+              properties: {
+                phrases: {
+                  type: "array",
+                  items: { type: "string" },
+                  minItems: 1,
+                  maxItems: 3,
+                },
+              },
+              required: ["phrases"],
+            },
+          },
+        ];
+
+        const ms = client.messages.stream({
+          model: "claude-sonnet-4-6",
+          max_tokens: 1024,
+          system: [
+            {
+              type: "text",
+              text: systemPrompt,
+              cache_control: { type: "ephemeral" },
+            },
+          ],
+          messages,
+          tools,
+        });
+
+        ms.on("text", (text: string) => {
+          controller.enqueue(sseFrame("delta", { text }));
+        });
+
+        const finalMessage = await ms.finalMessage();
+
+        // Surface validated phrases_held from any tool_use blocks.
+        for (const block of finalMessage.content) {
+          if (block.type === "tool_use" && block.name === "record_phrases_held") {
+            const input = block.input as { phrases?: unknown };
+            const raw = Array.isArray(input.phrases)
+              ? (input.phrases as unknown[]).filter(
+                  (p): p is string => typeof p === "string",
+                )
+              : [];
+            const { ok, bad } = verbatimOnly(raw, userTurnsText);
+            controller.enqueue(sseFrame("phrases_held", { phrases: ok }));
+            if (bad.length > 0) {
+              log.info("interview.turn.phrases_dropped", {
+                request_id: requestId,
+                bad_count: bad.length,
+              });
+            }
+          }
+        }
+
+        // Cache-hit telemetry — the difference between $5 and $50 over a session.
+        if (finalMessage.usage) {
+          log.info("interview.turn.usage", {
+            request_id: requestId,
+            input_tokens: finalMessage.usage.input_tokens,
+            output_tokens: finalMessage.usage.output_tokens,
+            cache_read_input_tokens:
+              finalMessage.usage.cache_read_input_tokens ?? 0,
+            cache_creation_input_tokens:
+              finalMessage.usage.cache_creation_input_tokens ?? 0,
+          });
+        }
+
+        controller.enqueue(sseFrame("done", {}));
+        controller.close();
+      } catch (err) {
+        log.error("interview.turn.failed", {
+          request_id: requestId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+        controller.enqueue(
+          sseFrame("error", { message: "interview turn failed" }),
+        );
+        controller.close();
+      }
+    },
+  });
+
+  return new Response(stream, {
+    status: 200,
+    headers: {
+      "Content-Type": "text/event-stream; charset=utf-8",
+      "Cache-Control": "no-cache, no-transform",
+      "X-Request-Id": requestId,
+    },
+  });
 }

--- a/app/api/spine/route.ts
+++ b/app/api/spine/route.ts
@@ -1,63 +1,134 @@
+import path from "node:path";
+import type Anthropic from "@anthropic-ai/sdk";
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
+import { anthropicForKey } from "@/lib/anthropic";
+import { keyOriginTag, readKey } from "@/lib/byo-key/server";
 import { SCRIPT } from "@/lib/demo";
+import { loadBuiltInGuides } from "@/lib/guides/loader";
+import { log } from "@/lib/logger";
+import { verbatimOnly } from "@/lib/spine/validate";
+import { FormSchema } from "@/lib/types/session";
 
 export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
 
-// Stub-mode contract — kept in sync with the real Haiku 4.5 route that
-// will land in #6/#9. The stub validates input the same way so caller-side
-// schema mistakes surface during stub development, not in production.
-const Body = z
-  .object({
-    guide_id: z.string().regex(/^[A-Za-z0-9_-]{3,64}$/, "guide_id must be 3-64 chars [A-Za-z0-9_-]"),
-    form: z.enum(["poem", "letter"]).optional(),
-    turns: z
-      .array(
-        z.object({
-          id: z.string(),
-          role: z.string(),
-          text: z.string().max(2000),
-        }),
-      )
-      .max(40)
-      .optional(),
-  })
-  .partial()
-  .optional();
+// ─────────── Schema ───────────
+
+const GUIDE_ID = z
+  .string()
+  .regex(/^[A-Za-z0-9_-]{3,64}$/, "guide_id must be 3-64 chars [A-Za-z0-9_-]");
+
+const TurnSchema = z.object({
+  id: z.string(),
+  role: z.enum(["guide", "user"]),
+  text: z.string().max(8000),
+});
+
+// Optional body — when omitted (or with no key), we serve the canned eulogy
+// SCRIPT for dev DX.
+const Body = z.object({
+  guide_id: GUIDE_ID.optional(),
+  form: FormSchema.optional(),
+  turns: z.array(TurnSchema).max(60).optional(),
+});
+type SpineBody = z.infer<typeof Body>;
+
+interface SpineCandidate {
+  text: string;
+  source_turn_id: string;
+  source_label: string;
+}
+interface StructureMovement {
+  label: string;
+  sub: string;
+}
+
+// ─────────── Memoized guide load ───────────
+
+let guidesCache: ReturnType<typeof loadBuiltInGuides> | null = null;
+function getBuiltInGuides() {
+  if (!guidesCache) {
+    guidesCache = loadBuiltInGuides(
+      path.join(process.cwd(), "prompts", "guides"),
+    );
+  }
+  return guidesCache;
+}
+
+// ─────────── POST handler ───────────
 
 /**
- * POST /api/spine — Spine extractor (stub).
+ * POST /api/spine — Spine extractor.
  *
- * Sprint-1 (this branch): returns the canonical eulogy SCRIPT's spine
- * candidates + structure regardless of input.
+ * Stub mode (no key, or empty body): returns the canned eulogy SCRIPT
+ * candidates + structure. Tagged with `X-Mean-It-Stub: 1`.
  *
- * Sprint-2 contract:
- *   request:  { turns: Turn[]; guide_id: string; form: Form }
- *   response: { candidates: DemoSpineCandidate[]; structure: DemoStructureMovement[] }
- *
- * Real implementation = Haiku 4.5 returning verbatim substrings of the
- * user-typed turns + a structure proposal calibrated to the active form.
+ * Real mode (BYO or env key + a body with at least one user turn):
+ * Haiku 4.5 returns 2-3 phrases. `verbatimOnly` validates each phrase
+ * against the user-turn text. On failure, retry once with a stricter
+ * prompt; on second failure, return 502 with diagnostic.
  */
 export async function POST(req: NextRequest): Promise<Response> {
-  // Validate when a body is provided (caller mistake catcher); accept the
-  // empty/no-body case for now since dev callers may not send anything.
+  const requestId = req.headers.get("x-request-id") ?? crypto.randomUUID();
+  const keyOrigin = keyOriginTag(req);
+  const key = readKey(req);
+
+  // Allow empty / no-body callers in stub mode.
+  let raw: unknown = {};
   const text = await req.text();
   if (text.trim().length > 0) {
-    let parsed: unknown;
     try {
-      parsed = JSON.parse(text);
+      raw = JSON.parse(text);
     } catch {
-      return NextResponse.json({ error: "expected JSON body" }, { status: 400 });
-    }
-    const result = Body.safeParse(parsed);
-    if (!result.success) {
       return NextResponse.json(
-        { error: "invalid body", issues: result.error.flatten() },
+        { error: "expected JSON body" },
         { status: 400 },
       );
     }
   }
 
+  const parsed = Body.safeParse(raw);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "invalid body", issues: parsed.error.flatten() },
+      { status: 400 },
+    );
+  }
+
+  const userTurns = (parsed.data.turns ?? []).filter((t) => t.role === "user");
+  const userTurnsText = userTurns.map((t) => t.text);
+
+  // Stub fallback: no key, no usable turns, or no guide.
+  if (
+    keyOrigin === "missing" ||
+    !key ||
+    userTurns.length === 0 ||
+    !parsed.data.guide_id
+  ) {
+    return stubResponse(requestId, keyOrigin);
+  }
+
+  return realResponse(
+    requestId,
+    keyOrigin,
+    key,
+    parsed.data,
+    userTurns,
+    userTurnsText,
+  );
+}
+
+// ─────────── Stub ───────────
+
+function stubResponse(
+  requestId: string,
+  keyOrigin: "byo" | "env" | "missing",
+): Response {
+  log.info("spine.stub", {
+    request_id: requestId,
+    key_origin: keyOrigin,
+  });
   return NextResponse.json(
     {
       stub: true,
@@ -66,4 +137,215 @@ export async function POST(req: NextRequest): Promise<Response> {
     },
     { headers: { "X-Mean-It-Stub": "1" } },
   );
+}
+
+// ─────────── Real (Haiku 4.5) ───────────
+
+async function realResponse(
+  requestId: string,
+  keyOrigin: "byo" | "env",
+  key: string,
+  body: SpineBody,
+  userTurns: ReadonlyArray<{ id: string; role: "guide" | "user"; text: string }>,
+  userTurnsText: string[],
+): Promise<Response> {
+  const guide_id = body.guide_id!;
+  const form = body.form ?? "letter";
+
+  const guide = getBuiltInGuides().find((g) => g.id === guide_id);
+  if (!guide) {
+    return NextResponse.json(
+      { error: `unknown guide_id: ${guide_id}` },
+      { status: 404 },
+    );
+  }
+
+  const client = anthropicForKey(key);
+
+  log.info("spine.start", {
+    request_id: requestId,
+    guide_id,
+    form,
+    user_turn_count: userTurns.length,
+    key_origin: keyOrigin,
+  });
+
+  // First attempt
+  let attempt = await callHaiku(client, guide.name, form, userTurns, false);
+  let validated = verbatimOnly(attempt.candidates, userTurnsText);
+
+  // One retry on validation failure with stricter prompt
+  if (validated.bad.length > 0) {
+    log.info("spine.retry", {
+      request_id: requestId,
+      bad_count: validated.bad.length,
+    });
+    attempt = await callHaiku(
+      client,
+      guide.name,
+      form,
+      userTurns,
+      true,
+      validated.bad,
+    );
+    validated = verbatimOnly(attempt.candidates, userTurnsText);
+  }
+
+  if (validated.bad.length > 0 || validated.ok.length === 0) {
+    log.error("spine.failed", {
+      request_id: requestId,
+      bad: validated.bad,
+      ok_count: validated.ok.length,
+    });
+    return NextResponse.json(
+      {
+        error:
+          "spine extractor returned non-verbatim phrases after one retry",
+        bad: validated.bad,
+      },
+      { status: 502 },
+    );
+  }
+
+  // Map ok phrases back to their source turn for the picker UI.
+  const candidates: SpineCandidate[] = validated.ok.map((phrase) => {
+    const source = userTurns.find((t) => t.text.includes(phrase.trim()));
+    return {
+      text: phrase,
+      source_turn_id: source?.id ?? userTurns[userTurns.length - 1]!.id,
+      source_label: source ? `from your answer · ${source.id}` : "from your answers",
+    };
+  });
+
+  log.info("spine.ok", {
+    request_id: requestId,
+    candidate_count: candidates.length,
+    structure_count: attempt.structure.length,
+  });
+
+  return NextResponse.json({
+    candidates,
+    structure: attempt.structure,
+  });
+}
+
+// ─────────── Haiku call ───────────
+
+interface HaikuAttemptResult {
+  candidates: string[];
+  structure: StructureMovement[];
+}
+
+async function callHaiku(
+  client: Anthropic,
+  guideName: string,
+  form: "poem" | "letter",
+  userTurns: ReadonlyArray<{ id: string; role: "guide" | "user"; text: string }>,
+  strictRetry: boolean,
+  badPhrases: string[] = [],
+): Promise<HaikuAttemptResult> {
+  const userText = userTurns
+    .map((t) => `[turn ${t.id}] ${t.text}`)
+    .join("\n\n");
+
+  const baseSystem = [
+    `You are a spine extractor for ${guideName}, working on a ${form} someone is writing.`,
+    "Read the user's accumulated turns. Pick 2 or 3 short phrases — each one a verbatim substring of one of the user's turns — that read as the spine of what they're trying to say. Phrases that other phrases hang from.",
+    "Then propose a 3-movement structure for the artifact (each movement: a label and a one-line sub).",
+    "",
+    "RULES",
+    "- Each phrase MUST be an exact substring of the user's text. No paraphrasing. No summarising. Copy the characters as they appear.",
+    "- Pick phrases of 4-12 words. Avoid trailing punctuation when possible.",
+    "- Pick phrases the user actually said, not phrases inferred from what they said.",
+    "- Use the `record_spine` tool to return the result. Do not return prose.",
+  ];
+  if (strictRetry && badPhrases.length > 0) {
+    baseSystem.push(
+      "",
+      "STRICTNESS REMINDER",
+      `Your previous attempt returned phrases that were not verbatim substrings: ${badPhrases.map((p) => JSON.stringify(p)).join(", ")}.`,
+      "Try again. Each phrase must appear character-for-character in the user's turns above. Copy from the source.",
+    );
+  }
+  const systemText = baseSystem.join("\n");
+
+  const tools: Anthropic.Tool[] = [
+    {
+      name: "record_spine",
+      description:
+        "Record 2-3 verbatim spine candidates plus a 3-movement structure proposal.",
+      input_schema: {
+        type: "object" as const,
+        properties: {
+          candidates: {
+            type: "array",
+            items: { type: "string" },
+            minItems: 2,
+            maxItems: 3,
+            description:
+              "Each candidate MUST be an exact substring of the user's turns.",
+          },
+          structure: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                label: { type: "string" },
+                sub: { type: "string" },
+              },
+              required: ["label", "sub"],
+            },
+            minItems: 3,
+            maxItems: 3,
+          },
+        },
+        required: ["candidates", "structure"],
+      },
+    },
+  ];
+
+  const result = await client.messages.create({
+    model: "claude-haiku-4-5-20251001",
+    max_tokens: 1024,
+    system: [
+      { type: "text", text: systemText, cache_control: { type: "ephemeral" } },
+    ],
+    messages: [
+      {
+        role: "user",
+        content: `User turns so far:\n\n${userText}\n\nReturn the spine via the record_spine tool.`,
+      },
+    ],
+    tools,
+    tool_choice: { type: "tool", name: "record_spine" },
+  });
+
+  for (const block of result.content) {
+    if (block.type === "tool_use" && block.name === "record_spine") {
+      const input = block.input as {
+        candidates?: unknown;
+        structure?: unknown;
+      };
+      const candidates = Array.isArray(input.candidates)
+        ? (input.candidates as unknown[]).filter(
+            (c): c is string => typeof c === "string",
+          )
+        : [];
+      const structureRaw = Array.isArray(input.structure)
+        ? (input.structure as unknown[])
+        : [];
+      const structure: StructureMovement[] = structureRaw
+        .map((s) => {
+          const obj = s as { label?: unknown; sub?: unknown };
+          return {
+            label: typeof obj.label === "string" ? obj.label : "",
+            sub: typeof obj.sub === "string" ? obj.sub : "",
+          };
+        })
+        .filter((m) => m.label.length > 0);
+      return { candidates, structure };
+    }
+  }
+
+  return { candidates: [], structure: [] };
 }

--- a/components/App.tsx
+++ b/components/App.tsx
@@ -4,6 +4,7 @@ import { useAppStore } from "@/lib/store";
 import { Chrome } from "./Chrome";
 import { PickMoment } from "./screens/PickMoment";
 import { GuidePicker } from "./screens/GuidePicker";
+import { Interview } from "./screens/Interview";
 import { Spine } from "./screens/Spine";
 import { Render } from "./screens/Render";
 import type { Guide } from "@/lib/guides/schema";
@@ -18,9 +19,9 @@ export function App({ guides }: { guides: Guide[] }) {
       <main>
         {step === "moment" && <PickMoment />}
         {step === "guide" && <GuidePicker guides={guides} />}
-        {step === "interview" && <div className="stage text-center">Interview screen coming soon...</div>}
+        {step === "interview" && <Interview />}
         {step === "spine" && <Spine />}
-        {step === "drafting" && <div className="stage text-center">Drafting screen coming soon...</div>}
+        {step === "drafting" && <div className="stage text-center">Drafting screen coming soon (Sprint 3).</div>}
         {step === "render" && <Render />}
       </main>
     </div>

--- a/components/screens/Interview.tsx
+++ b/components/screens/Interview.tsx
@@ -1,0 +1,383 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { MASCOTS, Mascot, type MascotId } from "@/components/mascots";
+import { getKey } from "@/lib/byo-key";
+import { actions, useAppStore } from "@/lib/store";
+import type { Turn } from "@/lib/types/session";
+
+function mascotForGuide(guide_id: string | null): MascotId | null {
+  if (!guide_id) return null;
+  for (const m of Object.values(MASCOTS)) {
+    if (m.guide_id === guide_id) return m.id;
+  }
+  return null;
+}
+
+export function Interview() {
+  const [state, dispatch] = useAppStore();
+  const { draft, theme, session_id, turns, emotion } = state;
+  const mascotId = mascotForGuide(draft.guide_id);
+
+  const [streamingText, setStreamingText] = useState("");
+  const [phrasesHeld, setPhrasesHeld] = useState<string[]>([]);
+  const [userInput, setUserInput] = useState("");
+  const [isStreaming, setIsStreaming] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const startedRef = useRef(false);
+
+  // Ensure a session_id exists before any turn is recorded — Turn.session_id
+  // is required by the canonical schema.
+  useEffect(() => {
+    if (!session_id) {
+      dispatch(actions.setSessionId(crypto.randomUUID()));
+    }
+  }, [session_id, dispatch]);
+
+  const runTurn = useCallback(
+    async (extraUserTurn?: Turn) => {
+      if (
+        !draft.guide_id ||
+        !draft.recipient ||
+        !draft.occasion ||
+        !draft.form
+      ) {
+        setError("Pick the moment + a guide before continuing.");
+        return;
+      }
+      setIsStreaming(true);
+      setStreamingText("");
+      setPhrasesHeld([]);
+      setError(null);
+
+      const turnsToSend = extraUserTurn ? [...turns, extraUserTurn] : turns;
+      let assistantText = "";
+
+      try {
+        const byoKey = getKey();
+        const res = await fetch("/api/interview/turn", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            ...(byoKey ? { "X-Anthropic-Key": byoKey } : {}),
+          },
+          body: JSON.stringify({
+            session: {
+              recipient: draft.recipient,
+              occasion: draft.occasion,
+              form: draft.form,
+            },
+            guide_id: draft.guide_id,
+            turns: turnsToSend,
+            theme,
+          }),
+        });
+
+        if (!res.ok) {
+          const errJson = (await res.json().catch(() => ({}))) as {
+            error?: string;
+          };
+          setError(errJson.error ?? `request failed (${res.status})`);
+          setIsStreaming(false);
+          return;
+        }
+
+        const ct = res.headers.get("Content-Type") ?? "";
+        if (!ct.includes("text/event-stream")) {
+          // Stub fallback — JSON shape from no-key path
+          const json = (await res.json()) as {
+            question?: string;
+            meta?: string | null;
+            phrases_held?: string[];
+          };
+          assistantText = json.question ?? "";
+          if (json.meta) assistantText += `\n\n— ${json.meta}`;
+          setStreamingText(assistantText);
+          setPhrasesHeld(json.phrases_held ?? []);
+        } else {
+          // Real SSE path
+          const reader = res.body?.getReader();
+          if (!reader) {
+            setError("response had no body");
+            setIsStreaming(false);
+            return;
+          }
+          const decoder = new TextDecoder();
+          let buffer = "";
+          while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            buffer += decoder.decode(value, { stream: true });
+            // Split on the SSE frame boundary (blank line). The trailing
+            // partial frame stays in `buffer` until the next chunk fills it.
+            let boundary = buffer.indexOf("\n\n");
+            while (boundary !== -1) {
+              const frame = buffer.slice(0, boundary);
+              buffer = buffer.slice(boundary + 2);
+              boundary = buffer.indexOf("\n\n");
+              if (!frame.trim()) continue;
+              let event = "message";
+              let data = "";
+              for (const line of frame.split("\n")) {
+                if (line.startsWith("event:")) event = line.slice(6).trim();
+                else if (line.startsWith("data:")) data = line.slice(5).trim();
+              }
+              try {
+                if (event === "delta") {
+                  const { text } = JSON.parse(data) as { text: string };
+                  assistantText += text;
+                  setStreamingText(assistantText);
+                } else if (event === "phrases_held") {
+                  const { phrases } = JSON.parse(data) as { phrases: string[] };
+                  setPhrasesHeld(phrases);
+                } else if (event === "error") {
+                  const { message } = JSON.parse(data) as { message: string };
+                  setError(message);
+                }
+                // 'done' frame ends the stream — reader.read() will report done next
+              } catch {
+                // malformed frame — drop silently rather than break the stream
+              }
+            }
+          }
+        }
+
+        // Persist the turn pair on success.
+        const ts = Date.now();
+        const sid = session_id || crypto.randomUUID();
+        if (extraUserTurn) {
+          dispatch(actions.appendTurn(extraUserTurn));
+        }
+        dispatch(
+          actions.appendTurn({
+            id: `g-${ts}`,
+            session_id: sid,
+            role: "guide",
+            text: assistantText.trim(),
+            ts,
+          }),
+        );
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "request failed");
+      } finally {
+        setIsStreaming(false);
+      }
+    },
+    [draft, theme, turns, session_id, dispatch],
+  );
+
+  // First-load: if no turns yet, fetch the opening question. If we already
+  // have turns (resuming), show the most recent guide turn.
+  useEffect(() => {
+    if (startedRef.current) return;
+    startedRef.current = true;
+    if (turns.length === 0 && draft.guide_id) {
+      void runTurn();
+    } else if (turns.length > 0) {
+      const lastGuide = [...turns].reverse().find((t) => t.role === "guide");
+      if (lastGuide) setStreamingText(lastGuide.text);
+    }
+  }, [turns, draft.guide_id, runTurn]);
+
+  const onSubmit = () => {
+    const text = userInput.trim();
+    if (!text || isStreaming) return;
+    const sid = session_id || crypto.randomUUID();
+    const userTurn: Turn = {
+      id: `u-${Date.now()}`,
+      session_id: sid,
+      role: "user",
+      text,
+      ts: Date.now(),
+    };
+    setUserInput("");
+    void runTurn(userTurn);
+  };
+
+  if (!draft.guide_id) {
+    return (
+      <div className="stage">
+        <div className="eyebrow">interview</div>
+        <h1 className="h-display tiny" style={{ marginTop: 12 }}>
+          Pick a guide first.
+        </h1>
+        <button
+          className="btn primary"
+          style={{ marginTop: 16 }}
+          onClick={() => dispatch(actions.setStep("guide"))}
+        >
+          back to guide picker →
+        </button>
+      </div>
+    );
+  }
+
+  const guideTurnCount = turns.filter((t) => t.role === "guide").length;
+  const userTurnCount = turns.filter((t) => t.role === "user").length;
+
+  return (
+    <div className="stage" style={{ maxWidth: 1180 }}>
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          marginBottom: 22,
+        }}
+      >
+        <div className="eyebrow">interview · {draft.guide_id}</div>
+        <span
+          className="muted"
+          style={{ fontFamily: "var(--t-mono)", fontSize: 10 }}
+        >
+          {guideTurnCount} questions · {userTurnCount} answers
+        </span>
+      </div>
+
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "1fr 1fr",
+          gap: 56,
+          alignItems: "start",
+        }}
+      >
+        {/* LEFT — guide + question + holding pane */}
+        <div style={{ paddingTop: 8 }}>
+          {mascotId && (
+            <div style={{ marginBottom: 22 }}>
+              <Mascot id={mascotId} emotion={emotion} size={84} />
+            </div>
+          )}
+          <div className="eyebrow" style={{ marginBottom: 10 }}>
+            the guide is asking
+          </div>
+          <div
+            className="serif-italic"
+            style={{ fontSize: 32, lineHeight: 1.25, color: "var(--t-ink)" }}
+          >
+            {streamingText || (
+              <span className="muted" style={{ fontStyle: "italic" }}>
+                listening…
+              </span>
+            )}
+            {isStreaming && (
+              <span
+                style={{
+                  display: "inline-block",
+                  width: 1.5,
+                  height: 22,
+                  background: "var(--t-ink)",
+                  marginLeft: 4,
+                  verticalAlign: "middle",
+                  animation: "blink 1s infinite",
+                }}
+              />
+            )}
+          </div>
+
+          {phrasesHeld.length > 0 && (
+            <div
+              className="card"
+              style={{
+                marginTop: 28,
+                padding: "14px 18px",
+                borderLeft: "2px solid var(--t-accent)",
+                animation: "fadein 600ms ease",
+              }}
+            >
+              <div className="eyebrow" style={{ color: "var(--t-accent)" }}>
+                holding · from your turn
+              </div>
+              <ul
+                style={{
+                  listStyle: "none",
+                  padding: 0,
+                  margin: "8px 0 0",
+                }}
+              >
+                {phrasesHeld.map((p) => (
+                  <li
+                    key={p}
+                    className="serif-italic"
+                    style={{
+                      fontSize: 17,
+                      fontStyle: "italic",
+                      color: "var(--t-ink)",
+                      marginTop: 4,
+                    }}
+                  >
+                    &ldquo;<span className="hl">{p}</span>&rdquo;
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+
+        {/* RIGHT — user input */}
+        <div>
+          <div className="eyebrow" style={{ marginBottom: 10 }}>
+            your turn · take your time
+          </div>
+          <textarea
+            className="textarea-prose"
+            value={userInput}
+            onChange={(e) => setUserInput(e.target.value)}
+            rows={7}
+            placeholder="something specific. one detail is enough."
+            style={{ fontSize: 19, minHeight: 200 }}
+            disabled={isStreaming}
+          />
+          <div
+            style={{
+              display: "flex",
+              justifyContent: "space-between",
+              marginTop: 14,
+              alignItems: "center",
+            }}
+          >
+            <span
+              className="muted"
+              style={{ fontFamily: "var(--t-mono)", fontSize: 10 }}
+            >
+              {userInput.split(/\s+/).filter(Boolean).length} words · all yours
+            </span>
+            <div style={{ display: "flex", gap: 8 }}>
+              <button
+                className="btn ghost sm"
+                onClick={() => dispatch(actions.setStep("spine"))}
+                disabled={turns.length < 2}
+                style={{ opacity: turns.length < 2 ? 0.4 : 1 }}
+              >
+                find the spine →
+              </button>
+              <button
+                className="btn primary"
+                onClick={onSubmit}
+                disabled={!userInput.trim() || isStreaming}
+                style={{
+                  opacity: !userInput.trim() || isStreaming ? 0.4 : 1,
+                }}
+              >
+                {isStreaming ? "listening…" : "send →"}
+              </button>
+            </div>
+          </div>
+          {error && (
+            <div
+              style={{
+                marginTop: 12,
+                color: "var(--t-accent)",
+                fontFamily: "var(--t-mono)",
+                fontSize: 11,
+              }}
+            >
+              {error}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/lib/anthropic.ts
+++ b/lib/anthropic.ts
@@ -1,10 +1,22 @@
 import Anthropic from "@anthropic-ai/sdk";
 import { env } from "./env";
 
-let client: Anthropic | null = null;
+let envSingleton: Anthropic | null = null;
 
+/**
+ * Env-keyed singleton. Use for routes that always read from
+ * `ANTHROPIC_API_KEY` and never accept a per-request key.
+ */
 export function anthropic(): Anthropic {
-  if (client) return client;
-  client = new Anthropic({ apiKey: env().ANTHROPIC_API_KEY });
-  return client;
+  if (envSingleton) return envSingleton;
+  envSingleton = new Anthropic({ apiKey: env().ANTHROPIC_API_KEY });
+  return envSingleton;
+}
+
+/**
+ * Per-request client for BYO-key flows. Do not cache — different requests
+ * may carry different keys. Pair with `readKey(req)` from `lib/byo-key/server`.
+ */
+export function anthropicForKey(key: string): Anthropic {
+  return new Anthropic({ apiKey: key });
 }

--- a/lib/interview/assemble-prompt.ts
+++ b/lib/interview/assemble-prompt.ts
@@ -1,0 +1,86 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import type { Guide } from "@/lib/guides/schema";
+import type { Form, Theme } from "@/lib/types/session";
+import { themeVoiceBlock } from "./theme-voice";
+
+export interface AssemblePromptInput {
+  guide: Guide;
+  recipient: string;
+  occasion: string;
+  form: Form;
+  theme?: Theme;
+}
+
+let templateCache: string | null = null;
+
+function loadTemplate(): string {
+  if (templateCache !== null) return templateCache;
+  const path = join(process.cwd(), "prompts", "interviewer.system.md");
+  templateCache = readFileSync(path, "utf-8");
+  return templateCache;
+}
+
+// Visible-for-testing — lets test harnesses reset between cases.
+export function _resetTemplateCache(): void {
+  templateCache = null;
+}
+
+/**
+ * Render the interviewer system prompt for one session.
+ *
+ * The template at `prompts/interviewer.system.md` has a doc preamble
+ * separated from the actual prompt body by `---`. Everything before the
+ * first `---` is documentation; everything after is the prompt.
+ *
+ * Supports a tiny subset of Handlebars syntax:
+ *   - `{{form}}`, `{{recipient_name}}`, `{{occasion}}`
+ *   - `{{guide.name}}`, `{{guide.sensibility}}`
+ *   - `{{#each guide.<field>}}\n- {{this}}\n{{/each}}` for the guide's
+ *     bullet-list arrays
+ *
+ * The theme voice block is appended after the persona body.
+ */
+export function assemblePrompt(input: AssemblePromptInput): string {
+  let out = loadTemplate();
+
+  // Drop the doc preamble (everything up to and including the first `---`).
+  const sepIdx = out.indexOf("---");
+  if (sepIdx !== -1) {
+    out = out.slice(sepIdx + 3).trimStart();
+  }
+
+  // Expand each-blocks for the guide's array fields.
+  const arrays: Array<readonly [string, readonly string[]]> = [
+    ["voice_rules", input.guide.voice_rules],
+    ["allowed", input.guide.allowed],
+    ["forbidden", input.guide.forbidden],
+    ["sample_meta_comments", input.guide.sample_meta_comments],
+    ["question_bank", input.guide.question_bank],
+  ];
+  for (const [field, items] of arrays) {
+    const re = new RegExp(
+      `\\{\\{#each guide\\.${field}\\}\\}[\\s\\S]*?\\{\\{/each\\}\\}`,
+      "g",
+    );
+    const bullets = items.map((s) => `- ${s}`).join("\n");
+    out = out.replace(re, bullets);
+  }
+
+  // Plain placeholder substitutions.
+  const replacements: Record<string, string> = {
+    "{{form}}": input.form,
+    "{{recipient_name}}": input.recipient,
+    "{{occasion}}": input.occasion,
+    "{{guide.name}}": input.guide.name,
+    "{{guide.sensibility}}": input.guide.sensibility,
+  };
+  for (const [needle, value] of Object.entries(replacements)) {
+    out = out.split(needle).join(value);
+  }
+
+  // Theme voice as a final block.
+  out = `${out.trimEnd()}\n\n## Theme voice\n\n${themeVoiceBlock(input.theme)}\n`;
+
+  return out;
+}

--- a/lib/interview/theme-voice.ts
+++ b/lib/interview/theme-voice.ts
@@ -1,0 +1,18 @@
+import type { Theme } from "@/lib/types/session";
+
+// Short instruction blocks appended to the assembled interviewer system
+// prompt, one per theme. Modulates voice without rewriting the persona.
+// Cute leans playful; gothic leans patient with silence — see DESIGN.md.
+export const THEME_VOICE: Record<Theme, string> = {
+  cute: "Lean playful and curious. Permission to use small surprises and delight, light textures, gentle wordplay. Never saccharine; the warmth is genuine, not performed.",
+  warm: "Low-key, family-shaped, conversational. Patient with the everyday — the kitchen, the Tuesday, the small habit. Treat the ordinary as load-bearing.",
+  quiet: "Patient with silence — leave room. Resist filling the gap when the user trails off. Solemn but never heavy-handed; let what hurts be quietly named.",
+  noir: "Comfortable with weight and shadow. Lean into the line that's almost too honest — the contradiction, the regret, the thing said too late. Don't tidy the mess.",
+  gothic: "Most patient with silence. Most willing to sit with what's unresolved. The line you almost don't ask is the one that matters. Spare prose; ceremonial weight.",
+};
+
+const DEFAULT_THEME: Theme = "warm";
+
+export function themeVoiceBlock(theme: Theme | undefined): string {
+  return THEME_VOICE[theme ?? DEFAULT_THEME];
+}

--- a/lib/spine/validate.ts
+++ b/lib/spine/validate.ts
@@ -1,0 +1,36 @@
+export interface VerbatimResult {
+  ok: string[];
+  bad: string[];
+}
+
+/**
+ * Partition `candidates` by whether each is an exact substring of the
+ * concatenated user-turn text. Case-sensitive after `.trim()` per #26.
+ *
+ * - The needle is `c.trim()`. Empty needles are bad.
+ * - The haystack is each turn `.trim()`-ed and joined with a single space,
+ *   so substrings that span turn boundaries are *not* matched (returning
+ *   them would let the model paraphrase across turns and pretend it's
+ *   verbatim).
+ * - Returned `ok`/`bad` entries are the original candidate strings (with
+ *   any leading/trailing whitespace preserved) so callers can echo them.
+ */
+export function verbatimOnly(
+  candidates: readonly string[],
+  turnsText: readonly string[],
+): VerbatimResult {
+  const haystacks = turnsText.map((t) => t.trim()).filter((t) => t.length > 0);
+  const ok: string[] = [];
+  const bad: string[] = [];
+  for (const c of candidates) {
+    const needle = c.trim();
+    if (needle.length === 0) {
+      bad.push(c);
+      continue;
+    }
+    const found = haystacks.some((h) => h.includes(needle));
+    if (found) ok.push(c);
+    else bad.push(c);
+  }
+  return { ok, bad };
+}

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -3,7 +3,14 @@
 import { useEffect, useReducer } from "react";
 import { z } from "zod";
 import { EMOTIONS, type Emotion } from "@/components/mascots";
-import { FormSchema, ThemeSchema, type Form, type Theme } from "@/lib/types/session";
+import {
+  FormSchema,
+  ThemeSchema,
+  TurnSchema,
+  type Form,
+  type Theme,
+  type Turn,
+} from "@/lib/types/session";
 
 export const STEPS_TUPLE = [
   "moment",
@@ -44,6 +51,11 @@ export interface AppState {
   emotion: Emotion;
   modal: ModalKind;
   draft: DraftSession;
+  // session_id ties Turn.session_id to a stable id across the flow. Empty
+  // string means "not yet started"; the Interview screen sets it on entry
+  // if absent.
+  session_id: string;
+  turns: Turn[];
 }
 
 export type Action =
@@ -53,6 +65,8 @@ export type Action =
   | { type: "set_emotion"; emotion: Emotion }
   | { type: "set_modal"; modal: ModalKind }
   | { type: "patch_draft"; patch: Partial<DraftSession> }
+  | { type: "set_session_id"; session_id: string }
+  | { type: "append_turn"; turn: Turn }
   | { type: "reset" };
 
 const STEPS: readonly Step[] = STEPS_TUPLE;
@@ -60,7 +74,8 @@ const EmotionSchema = z.enum(EMOTIONS as readonly [Emotion, ...Emotion[]]);
 
 // Persisted shape — mirrors AppState but every field is validated. Future
 // schema evolution requires bumping STORAGE_KEY (mean_it_app_state_v2 etc.)
-// or migrating in `loadInitial`.
+// or migrating in `loadInitial`. session_id and turns default so previously-
+// persisted v1 state without them still loads.
 const DraftSchema = z.object({
   recipient: z.string().default(""),
   occasion: z.string().default(""),
@@ -73,6 +88,8 @@ const PersistedSchema = z.object({
   emotion: EmotionSchema,
   modal: ModalKindSchema,
   draft: DraftSchema,
+  session_id: z.string().default(""),
+  turns: z.array(TurnSchema).default([]),
 });
 
 export const INITIAL_STATE: AppState = {
@@ -86,6 +103,8 @@ export const INITIAL_STATE: AppState = {
     form: null,
     guide_id: null,
   },
+  session_id: "",
+  turns: [],
 };
 
 export function reducer(state: AppState, action: Action): AppState {
@@ -105,6 +124,10 @@ export function reducer(state: AppState, action: Action): AppState {
       return { ...state, modal: action.modal };
     case "patch_draft":
       return { ...state, draft: { ...state.draft, ...action.patch } };
+    case "set_session_id":
+      return { ...state, session_id: action.session_id };
+    case "append_turn":
+      return { ...state, turns: [...state.turns, action.turn] };
     case "reset":
       return INITIAL_STATE;
   }
@@ -155,5 +178,10 @@ export const actions = {
     type: "patch_draft",
     patch,
   }),
+  setSessionId: (session_id: string): Action => ({
+    type: "set_session_id",
+    session_id,
+  }),
+  appendTurn: (turn: Turn): Action => ({ type: "append_turn", turn }),
   reset: (): Action => ({ type: "reset" }),
 };

--- a/tests/api/interview-turn-real.test.ts
+++ b/tests/api/interview-turn-real.test.ts
@@ -1,0 +1,178 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { NextRequest } from "next/server";
+
+// Mock state shared between the SDK mock and the test bodies. `vi.hoisted`
+// lifts this so the factory inside `vi.mock("@anthropic-ai/sdk")` can close
+// over it before the route module is imported.
+const sse = vi.hoisted(() => {
+  const handlers: Record<string, Array<(arg: unknown) => void>> = {};
+  const finalMessageMock = vi.fn();
+  const mockStream = {
+    on(event: string, handler: (arg: unknown) => void) {
+      (handlers[event] = handlers[event] ?? []).push(handler);
+      return mockStream;
+    },
+    finalMessage() {
+      return finalMessageMock();
+    },
+  };
+  const triggerText = (text: string) => {
+    (handlers.text ?? []).forEach((h) => (h as (t: string) => void)(text));
+  };
+  const reset = () => {
+    for (const k of Object.keys(handlers)) delete handlers[k];
+    finalMessageMock.mockReset();
+  };
+  return { mockStream, finalMessageMock, triggerText, reset };
+});
+
+vi.mock("@anthropic-ai/sdk", () => ({
+  default: vi.fn().mockImplementation(() => ({
+    messages: {
+      stream: vi.fn().mockReturnValue(sse.mockStream),
+      create: vi.fn(),
+    },
+  })),
+}));
+
+const { POST } = await import("@/app/api/interview/turn/route");
+
+function makeRequest(
+  body: object,
+  headers: Record<string, string> = {},
+): NextRequest {
+  return new Request("http://localhost/api/interview/turn", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...headers },
+    body: JSON.stringify(body),
+  }) as unknown as NextRequest;
+}
+
+const canonicalBody = {
+  session: { recipient: "Tomas", occasion: "eulogy", form: "letter" as const },
+  guide_id: "documentarian",
+  turns: [
+    { id: "g1", role: "guide" as const, text: "How did she answer the phone?" },
+    {
+      id: "u1",
+      role: "user" as const,
+      text: "Yes she said pronto when answering — every time.",
+    },
+  ],
+  theme: "quiet" as const,
+};
+const byoHeaders = { "X-Anthropic-Key": "sk-ant-test" };
+
+beforeEach(() => sse.reset());
+
+describe("POST /api/interview/turn — real mode SSE", () => {
+  it("streams delta tokens, then phrases_held, then done", async () => {
+    sse.finalMessageMock.mockImplementation(async () => {
+      sse.triggerText("What ");
+      sse.triggerText("did she ");
+      sse.triggerText("say?");
+      return {
+        content: [
+          {
+            type: "tool_use",
+            name: "record_phrases_held",
+            input: { phrases: ["she said pronto"] },
+          },
+        ],
+        usage: {
+          input_tokens: 200,
+          output_tokens: 8,
+          cache_read_input_tokens: 150,
+          cache_creation_input_tokens: 0,
+        },
+      };
+    });
+
+    const res = await POST(makeRequest(canonicalBody, byoHeaders));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toContain("text/event-stream");
+
+    const text = await res.text();
+
+    // Three deltas in order
+    expect(text).toContain("event: delta");
+    expect(text.indexOf("What ")).toBeGreaterThan(-1);
+    expect(text.indexOf("did she ")).toBeGreaterThan(text.indexOf("What "));
+    expect(text.indexOf("say?")).toBeGreaterThan(text.indexOf("did she "));
+
+    // phrases_held with the verbatim phrase
+    expect(text).toContain("event: phrases_held");
+    expect(text).toContain("she said pronto");
+
+    // done at the end
+    expect(text).toContain("event: done");
+    expect(text.lastIndexOf("event: done")).toBeGreaterThan(
+      text.indexOf("event: phrases_held"),
+    );
+  });
+
+  it("filters non-verbatim phrases out of phrases_held", async () => {
+    sse.finalMessageMock.mockImplementation(async () => {
+      sse.triggerText("Q?");
+      return {
+        content: [
+          {
+            type: "tool_use",
+            name: "record_phrases_held",
+            input: {
+              phrases: [
+                "she said pronto", // verbatim — kept
+                "she greeted strangers warmly", // paraphrase — dropped
+              ],
+            },
+          },
+        ],
+        usage: { input_tokens: 50, output_tokens: 2 },
+      };
+    });
+
+    const res = await POST(makeRequest(canonicalBody, byoHeaders));
+    const text = await res.text();
+    expect(text).toContain("she said pronto");
+    expect(text).not.toContain("she greeted strangers warmly");
+  });
+
+  it("emits done even when the model never calls the tool", async () => {
+    sse.finalMessageMock.mockImplementation(async () => {
+      sse.triggerText("Just text, no tool.");
+      return {
+        content: [{ type: "text", text: "Just text, no tool." }],
+        usage: { input_tokens: 10, output_tokens: 5 },
+      };
+    });
+
+    const res = await POST(makeRequest(canonicalBody, byoHeaders));
+    const text = await res.text();
+    expect(text).toContain("event: delta");
+    expect(text).not.toContain("event: phrases_held");
+    expect(text).toContain("event: done");
+  });
+
+  it("404s on an unknown guide_id", async () => {
+    const res = await POST(
+      makeRequest(
+        { ...canonicalBody, guide_id: "ghost-guide-xyz" },
+        byoHeaders,
+      ),
+    );
+    expect(res.status).toBe(404);
+    expect(sse.finalMessageMock).not.toHaveBeenCalled();
+  });
+
+  it("emits an error frame when the SDK throws", async () => {
+    sse.finalMessageMock.mockImplementation(async () => {
+      sse.triggerText("partial...");
+      throw new Error("network blew up");
+    });
+
+    const res = await POST(makeRequest(canonicalBody, byoHeaders));
+    const text = await res.text();
+    expect(text).toContain("event: error");
+    expect(text).toContain("interview turn failed");
+  });
+});

--- a/tests/api/spine.test.ts
+++ b/tests/api/spine.test.ts
@@ -1,0 +1,198 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { NextRequest } from "next/server";
+
+const mockCreate = vi.hoisted(() => vi.fn());
+
+vi.mock("@anthropic-ai/sdk", () => ({
+  default: vi.fn().mockImplementation(() => ({
+    messages: {
+      create: mockCreate,
+      stream: vi.fn(),
+    },
+  })),
+}));
+
+const { POST } = await import("@/app/api/spine/route");
+
+function makeRequest(
+  body: object | null,
+  headers: Record<string, string> = {},
+): NextRequest {
+  const init: RequestInit = {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      ...headers,
+    },
+  };
+  if (body !== null) init.body = JSON.stringify(body);
+  return new Request("http://localhost/api/spine", init) as unknown as NextRequest;
+}
+
+const happyResponse = (candidates: string[]) => ({
+  content: [
+    {
+      type: "tool_use",
+      name: "record_spine",
+      input: {
+        candidates,
+        structure: [
+          { label: "memory", sub: "the radio" },
+          { label: "phrase", sub: "the dial" },
+          { label: "inheritance", sub: "what passes down" },
+        ],
+      },
+    },
+  ],
+});
+
+const validBody = {
+  guide_id: "documentarian",
+  form: "letter" as const,
+  turns: [
+    {
+      id: "u1",
+      role: "user" as const,
+      text: "His hands tuned the radio dial like it was a violin string.",
+    },
+    {
+      id: "u2",
+      role: "user" as const,
+      text: "I tune the dial the same way now.",
+    },
+  ],
+};
+
+const byoHeaders = { "X-Anthropic-Key": "sk-ant-test" };
+
+beforeEach(() => {
+  mockCreate.mockReset();
+});
+
+describe("POST /api/spine — stub mode", () => {
+  it("returns canned candidates with no body", async () => {
+    const res = await POST(makeRequest(null));
+    expect(res.headers.get("X-Mean-It-Stub")).toBe("1");
+    const json = await res.json();
+    expect(json.stub).toBe(true);
+    expect(json.candidates).toBeInstanceOf(Array);
+    expect(json.candidates.length).toBeGreaterThanOrEqual(2);
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it("returns stub when no key is provided (even with valid body)", async () => {
+    const res = await POST(makeRequest(validBody));
+    const json = await res.json();
+    expect(json.stub).toBe(true);
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it("returns stub when key present but no user turns", async () => {
+    const res = await POST(
+      makeRequest(
+        { guide_id: "documentarian", form: "letter" },
+        byoHeaders,
+      ),
+    );
+    const json = await res.json();
+    expect(json.stub).toBe(true);
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it("400s on a malformed body", async () => {
+    const res = await POST(
+      makeRequest(
+        { guide_id: "x", turns: "not an array" } as unknown as object,
+        byoHeaders,
+      ),
+    );
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("POST /api/spine — real mode (Haiku mocked)", () => {
+  it("returns candidates + structure on a clean response", async () => {
+    mockCreate.mockResolvedValueOnce(
+      happyResponse([
+        "tuned the radio dial like it was a violin string",
+        "I tune the dial the same way now",
+      ]),
+    );
+
+    const res = await POST(makeRequest(validBody, byoHeaders));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.candidates).toHaveLength(2);
+    expect(json.candidates[0].text).toContain("violin string");
+    expect(json.candidates[0].source_turn_id).toBeTruthy();
+    expect(json.structure).toHaveLength(3);
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries once when a phrase is non-verbatim and succeeds on retry", async () => {
+    mockCreate
+      .mockResolvedValueOnce(
+        happyResponse([
+          "he loved the radio", // paraphrased — not a substring
+          "I tune the dial the same way now",
+        ]),
+      )
+      .mockResolvedValueOnce(
+        happyResponse([
+          "tuned the radio dial like it was a violin string",
+          "I tune the dial the same way now",
+        ]),
+      );
+
+    const res = await POST(makeRequest(validBody, byoHeaders));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.candidates).toHaveLength(2);
+    expect(mockCreate).toHaveBeenCalledTimes(2);
+  });
+
+  it("502s when retry also fails", async () => {
+    const bad = happyResponse([
+      "totally fabricated phrase",
+      "another one that's not in the text",
+    ]);
+    mockCreate.mockResolvedValueOnce(bad).mockResolvedValueOnce(bad);
+
+    const res = await POST(makeRequest(validBody, byoHeaders));
+    expect(res.status).toBe(502);
+    const json = await res.json();
+    expect(json.error).toContain("non-verbatim");
+    expect(json.bad).toBeInstanceOf(Array);
+    expect(mockCreate).toHaveBeenCalledTimes(2);
+  });
+
+  it("404s on an unknown guide_id", async () => {
+    const res = await POST(
+      makeRequest(
+        { ...validBody, guide_id: "nonexistent-guide" },
+        byoHeaders,
+      ),
+    );
+    expect(res.status).toBe(404);
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it("passes the second-attempt strict-retry instruction with the bad phrases", async () => {
+    mockCreate
+      .mockResolvedValueOnce(happyResponse(["paraphrased nonsense"]))
+      .mockResolvedValueOnce(
+        happyResponse([
+          "tuned the radio dial like it was a violin string",
+          "I tune the dial the same way now",
+        ]),
+      );
+
+    await POST(makeRequest(validBody, byoHeaders));
+
+    expect(mockCreate).toHaveBeenCalledTimes(2);
+    const secondCall = mockCreate.mock.calls[1]![0];
+    const systemBlocks = secondCall.system as Array<{ text: string }>;
+    expect(systemBlocks[0]!.text).toContain("STRICTNESS REMINDER");
+    expect(systemBlocks[0]!.text).toContain("paraphrased nonsense");
+  });
+});

--- a/tests/lib/interview-assemble-prompt.test.ts
+++ b/tests/lib/interview-assemble-prompt.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  _resetTemplateCache,
+  assemblePrompt,
+} from "@/lib/interview/assemble-prompt";
+import type { Guide } from "@/lib/guides/schema";
+
+const stubGuide: Guide = {
+  id: "test-guide",
+  name: "The Tester",
+  sensibility: "Sensible.",
+  best_for: ["test"],
+  voice_rules: ["be brief", "ask questions"],
+  allowed: ["ask follow-ups"],
+  forbidden: ["draft any line of the artifact"],
+  question_bank: ["Why?", "How so?"],
+  audit_flags: [{ name: "drafted_line", description: "..." }],
+  sample_meta_comments: ["pithy"],
+  description: "",
+  source: "builtin",
+};
+
+afterEach(() => _resetTemplateCache());
+
+describe("assemblePrompt", () => {
+  it("substitutes form / recipient / occasion into the template", () => {
+    const out = assemblePrompt({
+      guide: stubGuide,
+      recipient: "Tomas",
+      occasion: "eulogy",
+      form: "letter",
+    });
+    expect(out).toContain("**Tomas**");
+    expect(out).toContain("**eulogy**");
+    expect(out).toContain("**letter**");
+  });
+
+  it("substitutes guide.name and guide.sensibility", () => {
+    const out = assemblePrompt({
+      guide: stubGuide,
+      recipient: "x",
+      occasion: "x",
+      form: "letter",
+    });
+    expect(out).toContain("The Tester");
+    expect(out).toContain("Sensible.");
+  });
+
+  it("expands each-blocks for every guide array field", () => {
+    const out = assemblePrompt({
+      guide: stubGuide,
+      recipient: "x",
+      occasion: "x",
+      form: "letter",
+    });
+    // voice_rules
+    expect(out).toContain("- be brief");
+    expect(out).toContain("- ask questions");
+    // allowed
+    expect(out).toContain("- ask follow-ups");
+    // forbidden
+    expect(out).toContain("- draft any line of the artifact");
+    // sample_meta_comments
+    expect(out).toContain("- pithy");
+    // question_bank
+    expect(out).toContain("- Why?");
+    expect(out).toContain("- How so?");
+  });
+
+  it("strips the doc preamble (everything before ---)", () => {
+    const out = assemblePrompt({
+      guide: stubGuide,
+      recipient: "x",
+      occasion: "x",
+      form: "letter",
+    });
+    // The preamble describes the placeholders themselves, so its presence
+    // would mean we forgot to strip it.
+    expect(out).not.toContain("Render placeholders:");
+  });
+
+  it("appends a theme voice block; differs by theme", () => {
+    const gothic = assemblePrompt({
+      guide: stubGuide,
+      recipient: "x",
+      occasion: "x",
+      form: "letter",
+      theme: "gothic",
+    });
+    const cute = assemblePrompt({
+      guide: stubGuide,
+      recipient: "x",
+      occasion: "x",
+      form: "letter",
+      theme: "cute",
+    });
+    expect(gothic).toContain("Theme voice");
+    expect(cute).toContain("Theme voice");
+    expect(gothic).not.toEqual(cute);
+  });
+
+  it("defaults to the warm theme voice when theme is omitted", () => {
+    const omitted = assemblePrompt({
+      guide: stubGuide,
+      recipient: "x",
+      occasion: "x",
+      form: "letter",
+    });
+    const warm = assemblePrompt({
+      guide: stubGuide,
+      recipient: "x",
+      occasion: "x",
+      form: "letter",
+      theme: "warm",
+    });
+    expect(omitted).toEqual(warm);
+  });
+
+  it("leaves no unresolved {{ placeholders }}", () => {
+    const out = assemblePrompt({
+      guide: stubGuide,
+      recipient: "x",
+      occasion: "x",
+      form: "letter",
+      theme: "quiet",
+    });
+    expect(out).not.toMatch(/\{\{[^}]+\}\}/);
+  });
+});

--- a/tests/lib/spine-validate.test.ts
+++ b/tests/lib/spine-validate.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { verbatimOnly } from "@/lib/spine/validate";
+
+describe("verbatimOnly", () => {
+  it("matches exact substrings within a single turn", () => {
+    const turns = ["He always said pronto when he answered the phone."];
+    const { ok, bad } = verbatimOnly(["pronto", "answered the phone"], turns);
+    expect(ok).toEqual(["pronto", "answered the phone"]);
+    expect(bad).toEqual([]);
+  });
+
+  it("rejects paraphrased candidates", () => {
+    const turns = ["He kept a notebook in his coat pocket."];
+    const { ok, bad } = verbatimOnly(
+      ["He had a notebook", "in his coat pocket"],
+      turns,
+    );
+    expect(ok).toEqual(["in his coat pocket"]);
+    expect(bad).toEqual(["He had a notebook"]);
+  });
+
+  it("rejects empty / whitespace-only candidates", () => {
+    const { ok, bad } = verbatimOnly(["", "  "], ["any text"]);
+    expect(ok).toEqual([]);
+    expect(bad).toEqual(["", "  "]);
+  });
+
+  it("matches across multiple turns (per-turn search)", () => {
+    const turns = ["First turn text.", "Second turn with the line."];
+    const { ok } = verbatimOnly(["with the line"], turns);
+    expect(ok).toEqual(["with the line"]);
+  });
+
+  it("does not match strings that span turn boundaries", () => {
+    // The candidate is built from words drawn from two different turns;
+    // verbatim-only shouldn't accept it since that lets the model fabricate
+    // continuity that wasn't actually said.
+    const turns = ["Tomas kept a notebook.", "His hands tuned the radio."];
+    const { ok, bad } = verbatimOnly(
+      ["a notebook. His hands tuned the radio"],
+      turns,
+    );
+    expect(ok).toEqual([]);
+    expect(bad).toEqual(["a notebook. His hands tuned the radio"]);
+  });
+
+  it("is case-sensitive", () => {
+    const turns = ["The world is wide."];
+    const { ok, bad } = verbatimOnly(["the world is wide"], turns);
+    expect(ok).toEqual([]);
+    expect(bad).toEqual(["the world is wide"]);
+  });
+
+  it("preserves the original candidate string in the result", () => {
+    const turns = ["clean substring here"];
+    // Whitespace is trimmed for the search but the original is echoed back.
+    const { ok } = verbatimOnly(["  substring  "], turns);
+    expect(ok).toEqual(["  substring  "]);
+  });
+
+  it("returns empty ok and bad when both inputs are empty", () => {
+    const result = verbatimOnly([], []);
+    expect(result.ok).toEqual([]);
+    expect(result.bad).toEqual([]);
+  });
+});

--- a/tests/lib/store.test.ts
+++ b/tests/lib/store.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import { INITIAL_STATE, actions, reducer } from "@/lib/store";
+import type { Turn } from "@/lib/types/session";
+
+describe("reducer", () => {
+  it("set_step changes the step", () => {
+    const next = reducer(INITIAL_STATE, actions.setStep("guide"));
+    expect(next.step).toBe("guide");
+  });
+
+  it("next_step advances through the flow in order", () => {
+    const order = [
+      "moment",
+      "guide",
+      "interview",
+      "spine",
+      "drafting",
+      "render",
+    ] as const;
+    let state = INITIAL_STATE;
+    for (let i = 1; i < order.length; i++) {
+      state = reducer(state, actions.nextStep());
+      expect(state.step).toBe(order[i]);
+    }
+  });
+
+  it("next_step wraps from render back to moment", () => {
+    const onRender = { ...INITIAL_STATE, step: "render" as const };
+    const wrapped = reducer(onRender, actions.nextStep());
+    expect(wrapped.step).toBe("moment");
+  });
+
+  it("set_theme changes the theme", () => {
+    const next = reducer(INITIAL_STATE, actions.setTheme("gothic"));
+    expect(next.theme).toBe("gothic");
+  });
+
+  it("set_emotion changes the emotion", () => {
+    const next = reducer(INITIAL_STATE, actions.setEmotion("moved"));
+    expect(next.emotion).toBe("moved");
+  });
+
+  it("set_modal opens and closes modals", () => {
+    const opened = reducer(INITIAL_STATE, actions.setModal("download"));
+    expect(opened.modal).toBe("download");
+    const closed = reducer(opened, actions.setModal(null));
+    expect(closed.modal).toBeNull();
+  });
+
+  it("patch_draft merges partial patches into the draft", () => {
+    const r1 = reducer(
+      INITIAL_STATE,
+      actions.patchDraft({ recipient: "Tomas" }),
+    );
+    expect(r1.draft.recipient).toBe("Tomas");
+    expect(r1.draft.occasion).toBe("");
+
+    const r2 = reducer(r1, actions.patchDraft({ occasion: "eulogy" }));
+    expect(r2.draft.recipient).toBe("Tomas");
+    expect(r2.draft.occasion).toBe("eulogy");
+  });
+
+  it("reset returns to the initial state", () => {
+    const dirty = reducer(INITIAL_STATE, actions.setStep("render"));
+    const dirtier = reducer(dirty, actions.setTheme("gothic"));
+    const clean = reducer(dirtier, actions.reset());
+    expect(clean).toEqual(INITIAL_STATE);
+  });
+
+  it("does not mutate the previous state", () => {
+    const before = INITIAL_STATE;
+    const after = reducer(before, actions.setTheme("noir"));
+    expect(before.theme).toBe("quiet");
+    expect(after.theme).toBe("noir");
+    expect(after).not.toBe(before);
+  });
+
+  it("set_session_id assigns a session id without disturbing other state", () => {
+    const next = reducer(INITIAL_STATE, actions.setSessionId("session-abc"));
+    expect(next.session_id).toBe("session-abc");
+    expect(next.step).toBe(INITIAL_STATE.step);
+    expect(next.turns).toEqual(INITIAL_STATE.turns);
+  });
+
+  it("append_turn pushes turns immutably", () => {
+    const turn1: Turn = {
+      id: "g1",
+      session_id: "s1",
+      role: "guide",
+      text: "First question?",
+      ts: 1,
+    };
+    const turn2: Turn = {
+      id: "u1",
+      session_id: "s1",
+      role: "user",
+      text: "First answer.",
+      ts: 2,
+    };
+    const after1 = reducer(INITIAL_STATE, actions.appendTurn(turn1));
+    expect(after1.turns).toEqual([turn1]);
+    const after2 = reducer(after1, actions.appendTurn(turn2));
+    expect(after2.turns).toEqual([turn1, turn2]);
+    // earlier state's array unchanged
+    expect(after1.turns).toEqual([turn1]);
+    expect(INITIAL_STATE.turns).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Sprint 2 of #26 — real interviewer + spine + Interview screen

Single-handed (Pruthvi cut). All Sprint-2 acceptance items in #26 hit; Sprint-3 / Sprint-4 follow on dedicated branches per the PR strategy.

### What landed

**Routes (rewritten; stub fallback preserved on no-key path)**

| Route | Behavior |
|---|---|
| `POST /api/interview/turn` | Sonnet 4.6 SSE. System block via `lib/interview/assemble-prompt` (renders `prompts/interviewer.system.md` + theme voice, with `cache_control: { type: 'ephemeral' }`). `record_phrases_held` tool — phrases validated by `verbatimOnly` against user turns; non-substring phrases dropped. Events: `delta` / `phrases_held` / `done` / `error`. Accepts canonical `{ session, guide_id, turns, theme? }` AND legacy `{ guide_id, turn_index, user_text? }` during transition. |
| `POST /api/spine` | Haiku 4.5 with structured tool output. Each candidate validated as a verbatim substring of user turns. **One retry** with stricter prompt on failure; **502** with diagnostic on second failure. Stub fallback preserved. |

**Foundation libs**

- `lib/anthropic.ts` — adds `anthropicForKey(key)` per-request factory. Existing env-keyed singleton untouched.
- `lib/interview/theme-voice.ts` — five voice-modulation blocks (cute / warm / quiet / noir / gothic). Default warm.
- `lib/interview/assemble-prompt.ts` — tiny Handlebars-subset renderer; strips doc preamble before `---`; expands `{{#each guide.<field>}}` for the five array fields; appends theme voice.
- `lib/spine/validate.ts` — `verbatimOnly(candidates, turns)`. Per-turn search (no cross-turn fabrication). Case-sensitive after `.trim()` per #26 constraint.

**Store + screen**

- `lib/store.ts` — adds `AppState.session_id` and `AppState.turns` + `setSessionId` / `appendTurn` actions. `PersistedSchema` extended with `default([])` for `turns` and `default("")` for `session_id` so existing v1 localStorage upgrades without a storage-key bump.
- `components/screens/Interview.tsx` — split-A layout, mascot left, textarea right, SSE consumer with X-Anthropic-Key forwarding, falls through to JSON when the route is in stub mode, persists `Turn[]` to store on success, holding-pane consumes `phrases_held` events.
- `components/App.tsx` — routes `step === "interview"` to `Interview`.

### Tests (28 new, 137 / 137 across 16 files)

- `tests/lib/store.test.ts` (11) — every reducer action including `appendTurn` immutability and `setSessionId`.
- `tests/lib/interview-assemble-prompt.test.ts` (7) — placeholder substitution, each-block expansion for every guide array, doc-preamble stripping, theme modulation, default theme behavior, "no unresolved `{{}}`".
- `tests/lib/spine-validate.test.ts` (7) — exact / paraphrased / empty / cross-turn / case-sensitivity / whitespace / empty-input.
- `tests/api/spine.test.ts` (9) — stub paths (no body / no key / no user turns / malformed body), happy real path, retry-then-success, retry-then-fail (502), 404 unknown guide, strict-retry instruction passes the bad phrases.
- `tests/api/interview-turn-real.test.ts` (5) — SSE event order, non-verbatim phrases dropped, done without tool call, 404, error frame on SDK throw.

### Acceptance items (#26 § Sprint 2)

- [x] `lib/anthropic.ts` extended with `anthropicForKey(key)`
- [x] `lib/interview/assemble-prompt.ts` (Handlebars subset, theme voice appended)
- [x] `lib/spine/validate.ts` (`verbatimOnly`)
- [x] `app/api/interview/turn/route.ts` rewritten — SSE, Sonnet 4.6, `cache_control: ephemeral`, `record_phrases_held` tool, stub fallback
- [x] `app/api/spine/route.ts` rewritten — Haiku 4.5, structured output, validation + 1 retry + 502 + stub fallback
- [x] Body accepts canonical AND legacy shapes
- [x] `components/screens/Interview.tsx` — split-A, SSE consumer, persists Turn[], holding-pane, specific empty-state copy
- [x] All required tests
- [ ] **Edge runtime — deviation, see below.** Manual smoke with a real key — see deferred note below.

### Notes & deviations

- **Runtime is `nodejs`, not `edge`.** `lib/guides/loader.loadBuiltInGuides` uses `node:fs` to read `prompts/guides/*.guide.md` at request time. Building a const-bundle of guides at compile time so the route can run in Edge is reasonable follow-up but out of scope for Sprint 2. The streaming response works identically through `Response` + `ReadableStream`. Documented in `app/api/interview/turn/route.ts`.
- **Manual smoke deferred** to merge time — running the dev server with a live `ANTHROPIC_API_KEY` should show a non-zero `cache_read_input_tokens` on the second turn (the assembled system prompt is ~1500-2500 tokens, well above the 1024-token cache floor). I'll do this against the merged branch before Sprint 3 starts; happy to do it on a branch deploy if available.

### Gates

```
tsc --noEmit               ✓
vitest run                 137 / 137 across 16 files
next lint                  ✓
next build                 ✓ (production build, all routes resolved)
```

Refs #26 (Sprint 2 of three; Sprint 3 + 4 land on `feat/sprint-3-provenance-audit-critique` and `feat/sprint-4-guide-share` respectively).