### PR TITLE
feat: provenance + audit + critique + Drafting/Render upgrades (refs #26)

### DIFF
--- a/app/api/audit/route.ts
+++ b/app/api/audit/route.ts
@@ -1,0 +1,92 @@
+import path from "node:path";
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { anthropicForKey } from "@/lib/anthropic";
+import { keyOriginTag, readKey } from "@/lib/byo-key/server";
+import { loadBuiltInGuides } from "@/lib/guides/loader";
+import { runAudit } from "@/lib/interview/audit-middleware";
+import { log } from "@/lib/logger";
+
+export const runtime = "nodejs";
+
+const Body = z.object({
+  message: z.string().min(1).max(8000),
+  guide_id: z
+    .string()
+    .regex(/^[A-Za-z0-9_-]{3,64}$/, "guide_id must be 3-64 chars [A-Za-z0-9_-]"),
+});
+
+let guidesCache: ReturnType<typeof loadBuiltInGuides> | null = null;
+function getBuiltInGuides() {
+  if (!guidesCache) {
+    guidesCache = loadBuiltInGuides(
+      path.join(process.cwd(), "prompts", "guides"),
+    );
+  }
+  return guidesCache;
+}
+
+/**
+ * POST /api/audit — flag-driven ghostwriter audit.
+ *
+ * Stub mode (no key): returns `{ stub: true, flags_tripped: [], reason: "" }`
+ * so dev DX isn't regressed. Real mode runs Haiku 4.5 against the active
+ * guide's `audit_flags` via `runAudit` from
+ * `lib/interview/audit-middleware`.
+ */
+export async function POST(req: NextRequest): Promise<Response> {
+  const requestId = req.headers.get("x-request-id") ?? crypto.randomUUID();
+  const keyOrigin = keyOriginTag(req);
+  const key = readKey(req);
+
+  let raw: unknown;
+  try {
+    raw = await req.json();
+  } catch {
+    return NextResponse.json(
+      { error: "expected JSON body" },
+      { status: 400 },
+    );
+  }
+
+  const parsed = Body.safeParse(raw);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "invalid body", issues: parsed.error.flatten() },
+      { status: 400 },
+    );
+  }
+
+  const { message, guide_id } = parsed.data;
+  const guide = getBuiltInGuides().find((g) => g.id === guide_id);
+  if (!guide) {
+    return NextResponse.json(
+      { error: `unknown guide_id: ${guide_id}` },
+      { status: 404 },
+    );
+  }
+
+  if (!key || keyOrigin === "missing") {
+    log.info("audit.stub", { request_id: requestId, key_origin: keyOrigin });
+    return NextResponse.json({
+      stub: true,
+      flags_tripped: [],
+      reason: "",
+    });
+  }
+
+  const client = anthropicForKey(key);
+  const result = await runAudit({ message, guide, client });
+
+  log.info("audit.ok", {
+    request_id: requestId,
+    guide_id,
+    flag_count: result.flags_tripped.length,
+    blocked: !result.allow,
+  });
+
+  return NextResponse.json({
+    flags_tripped: result.flags_tripped,
+    reason: result.reason,
+  });
+}

--- a/app/api/draft/critique/route.ts
+++ b/app/api/draft/critique/route.ts
@@ -1,33 +1,59 @@
+import path from "node:path";
+import type Anthropic from "@anthropic-ai/sdk";
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
+import { anthropicForKey } from "@/lib/anthropic";
 import { keyOriginTag, readKey } from "@/lib/byo-key/server";
+import { loadBuiltInGuides } from "@/lib/guides/loader";
 import { log } from "@/lib/logger";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-// Canned critique cards for the v1 stub. Three buckets per Drafting_A
-// wireframe: cliché flag, question, verified-yours. Real Sonnet 4.6 critic
-// ships in #9.
+// ─────────── Schemas ───────────
 
 const CLICHE_PATTERNS: ReadonlyArray<{ pattern: RegExp; reason: string }> = [
-  { pattern: /forever in our hearts/i, reason: '"forever in our hearts" is a stock phrase. you noticed garlic on a pillow — keep going specific.' },
-  { pattern: /light of my life/i, reason: '"light of my life" is borrowed warmth. what specifically did her presence change?' },
-  { pattern: /gone too soon/i, reason: '"gone too soon" is a cliché. when exactly do you miss her? at what moment of the day?' },
-  { pattern: /will be missed/i, reason: '"will be missed" is passive — it lets the writer off the hook. who specifically is missing what?' },
+  {
+    pattern: /forever in our hearts/i,
+    reason:
+      '"forever in our hearts" is a stock phrase. you noticed garlic on a pillow — keep going specific.',
+  },
+  {
+    pattern: /light of my life/i,
+    reason:
+      '"light of my life" is borrowed warmth. what specifically did her presence change?',
+  },
+  {
+    pattern: /gone too soon/i,
+    reason:
+      '"gone too soon" is a cliché. when exactly do you miss her? at what moment of the day?',
+  },
+  {
+    pattern: /will be missed/i,
+    reason:
+      '"will be missed" is passive — it lets the writer off the hook. who specifically is missing what?',
+  },
 ];
 
 // `draft.max(5000)` caps the input so the O(n²) longestSharedRun helper
 // can't be weaponized as a CPU saturation vector on this unauthenticated
-// stub. Real critic in #9 uses Sonnet 4.6 — same cap will apply on the
-// upstream payload. `turns.max` mirrors that intent for the user-turn corpus.
+// stub. The same cap applies to the upstream payload in real mode.
+// `turns.max` mirrors that intent for the user-turn corpus.
 const Body = z.object({
   draft: z.string().min(1).max(5000),
   turns: z
-    .array(z.object({ id: z.string(), role: z.string(), text: z.string().max(2000) }))
+    .array(
+      z.object({
+        id: z.string(),
+        role: z.string(),
+        text: z.string().max(2000),
+      }),
+    )
     .max(40)
     .default([]),
-  guide_id: z.string().regex(/^[A-Za-z0-9_-]{3,64}$/, "guide_id must be 3-64 chars [A-Za-z0-9_-]"),
+  guide_id: z
+    .string()
+    .regex(/^[A-Za-z0-9_-]{3,64}$/, "guide_id must be 3-64 chars [A-Za-z0-9_-]"),
   theme: z.enum(["cute", "warm", "quiet", "noir", "gothic"]).optional(),
 });
 
@@ -36,6 +62,27 @@ interface CritiqueCard {
   line_ref?: string;
   body: string;
 }
+
+// ─────────── Memoized guide load ───────────
+
+let guidesCache: ReturnType<typeof loadBuiltInGuides> | null = null;
+function getBuiltInGuides() {
+  if (!guidesCache) {
+    guidesCache = loadBuiltInGuides(
+      path.join(process.cwd(), "prompts", "guides"),
+    );
+  }
+  return guidesCache;
+}
+
+// ─────────── SSE helpers ───────────
+
+const ENCODER = new TextEncoder();
+function sseFrame(event: string, data: unknown): Uint8Array {
+  return ENCODER.encode(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`);
+}
+
+// ─────────── POST handler ───────────
 
 export async function POST(req: NextRequest) {
   const requestId = req.headers.get("x-request-id") ?? crypto.randomUUID();
@@ -46,7 +93,10 @@ export async function POST(req: NextRequest) {
   try {
     body = await req.json();
   } catch {
-    return NextResponse.json({ error: "expected JSON body" }, { status: 400 });
+    return NextResponse.json(
+      { error: "expected JSON body" },
+      { status: 400 },
+    );
   }
 
   const parsed = Body.safeParse(body);
@@ -57,17 +107,24 @@ export async function POST(req: NextRequest) {
     );
   }
 
-  const cards = buildCannedCritique(parsed.data.draft, parsed.data.turns);
-  log.info("draft.critique.stub", {
-    request_id: requestId,
-    key_origin: keyOrigin,
-    has_key: Boolean(key),
-    cards: cards.length,
-    guide_id: parsed.data.guide_id,
-  });
+  // Stub mode: keep the existing JSON contract for dev DX.
+  if (keyOrigin === "missing" || !key) {
+    const cards = buildCannedCritique(parsed.data.draft, parsed.data.turns);
+    log.info("draft.critique.stub", {
+      request_id: requestId,
+      key_origin: keyOrigin,
+      has_key: Boolean(key),
+      cards: cards.length,
+      guide_id: parsed.data.guide_id,
+    });
+    return NextResponse.json({ stub: true, cards });
+  }
 
-  return NextResponse.json({ stub: true, cards });
+  // Real mode: stream Sonnet's critique cards as SSE.
+  return realCritiqueResponse(requestId, keyOrigin, parsed.data, key);
 }
+
+// ─────────── Stub critique ───────────
 
 function buildCannedCritique(
   draft: string,
@@ -79,7 +136,7 @@ function buildCannedCritique(
     const m = draft.match(pattern);
     if (m) {
       cards.push({ kind: "cliche", line_ref: m[0], body: reason });
-      break; // one cliché flag per pass keeps the right pane focused
+      break;
     }
   }
 
@@ -91,14 +148,10 @@ function buildCannedCritique(
     });
   }
 
-  // Naive verified-yours: surface the longest user-turn substring also in the
-  // draft. Real provenance matcher (#9) replaces this.
   const userText = turns
     .filter((t) => t.role === "user")
     .map((t) => t.text)
     .join(" ");
-  // 6 words ≈ a poem line; tuned for stub-mode noise vs signal. Real
-  // provenance matcher in #9 uses edit-distance, not a hard word floor.
   const verbatim = longestSharedRun(draft, userText, 6);
   if (verbatim) {
     cards.push({
@@ -118,7 +171,11 @@ function buildCannedCritique(
   return cards;
 }
 
-function longestSharedRun(a: string, b: string, minWords: number): string | null {
+function longestSharedRun(
+  a: string,
+  b: string,
+  minWords: number,
+): string | null {
   if (!a || !b) return null;
   const aWords = a.split(/\s+/);
   for (let len = aWords.length; len >= minWords; len--) {
@@ -129,4 +186,177 @@ function longestSharedRun(a: string, b: string, minWords: number): string | null
     }
   }
   return null;
+}
+
+// ─────────── Real critique (Sonnet 4.6 SSE) ───────────
+
+async function realCritiqueResponse(
+  requestId: string,
+  keyOrigin: "byo" | "env",
+  data: z.infer<typeof Body>,
+  key: string,
+): Promise<Response> {
+  const guide = getBuiltInGuides().find((g) => g.id === data.guide_id);
+  if (!guide) {
+    return NextResponse.json(
+      { error: `unknown guide_id: ${data.guide_id}` },
+      { status: 404 },
+    );
+  }
+
+  const userTurns = data.turns
+    .filter((t) => t.role === "user")
+    .map((t) => `[${t.id}] ${t.text}`)
+    .join("\n\n");
+  const themeBlock = data.theme ? `Theme: ${data.theme}.` : "";
+
+  const systemText = [
+    `You are a creative critic working with the guide ${guide.name}.`,
+    "The user is drafting a piece based on their interview turns. Read their draft and produce 1-4 critique cards.",
+    "",
+    "There are exactly THREE card kinds:",
+    '- "cliche" — a stock phrase, borrowed sentiment ("forever in our hearts", "light of my life", "gone too soon"). Suggest cutting; gesture at the user\'s own specifics.',
+    '- "question" — a real ambiguity in the draft. ("did you mean X or Y? both are yours, just pick one")',
+    '- "verified" — a line lifted directly from the user\'s interview turns. Positive reinforcement; encourage keeping.',
+    "",
+    "RULES",
+    "- You may not draft any line in the artifact's register. No example replacements. No 'try writing it like this'.",
+    "- Flag, ask, or affirm. That is all.",
+    "- Output one card per record_critique_card tool call. Up to 4 calls total. Order: most important first.",
+    "- Skip a card kind entirely if there's nothing legitimate to say about it.",
+    "",
+    themeBlock,
+  ]
+    .filter(Boolean)
+    .join("\n");
+
+  const tools: Anthropic.Tool[] = [
+    {
+      name: "record_critique_card",
+      description:
+        "Record one critique card. Call multiple times — once per card. Up to 4 cards total.",
+      input_schema: {
+        type: "object" as const,
+        properties: {
+          kind: {
+            type: "string",
+            enum: ["cliche", "question", "verified"],
+          },
+          line_ref: {
+            type: "string",
+            description:
+              "The specific text from the draft this card refers to. Optional.",
+          },
+          body: {
+            type: "string",
+            description: "The critique text shown to the user.",
+          },
+        },
+        required: ["kind", "body"],
+      },
+    },
+  ];
+
+  const stream = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      try {
+        const client = anthropicForKey(key);
+        const ms = client.messages.stream({
+          model: "claude-sonnet-4-6",
+          max_tokens: 1024,
+          system: [
+            {
+              type: "text",
+              text: systemText,
+              cache_control: { type: "ephemeral" },
+            },
+          ],
+          messages: [
+            {
+              role: "user",
+              content: `User's interview turns:\n\n${userTurns || "(no turns yet)"}\n\nDraft so far:\n\n${data.draft}\n\nProduce critique cards via the record_critique_card tool.`,
+            },
+          ],
+          tools,
+        });
+
+        const finalMessage = await ms.finalMessage();
+
+        let cardCount = 0;
+        for (const block of finalMessage.content) {
+          if (
+            block.type === "tool_use" &&
+            block.name === "record_critique_card"
+          ) {
+            const input = block.input as {
+              kind?: unknown;
+              line_ref?: unknown;
+              body?: unknown;
+            };
+            const kind =
+              input.kind === "cliche" ||
+              input.kind === "question" ||
+              input.kind === "verified"
+                ? input.kind
+                : null;
+            const body =
+              typeof input.body === "string" ? input.body : null;
+            if (kind && body) {
+              controller.enqueue(
+                sseFrame("card", {
+                  kind,
+                  line_ref:
+                    typeof input.line_ref === "string"
+                      ? input.line_ref
+                      : null,
+                  body,
+                }),
+              );
+              cardCount++;
+            }
+          }
+        }
+
+        if (finalMessage.usage) {
+          log.info("draft.critique.usage", {
+            request_id: requestId,
+            input_tokens: finalMessage.usage.input_tokens,
+            output_tokens: finalMessage.usage.output_tokens,
+            cache_read_input_tokens:
+              finalMessage.usage.cache_read_input_tokens ?? 0,
+            cache_creation_input_tokens:
+              finalMessage.usage.cache_creation_input_tokens ?? 0,
+          });
+        }
+
+        log.info("draft.critique.ok", {
+          request_id: requestId,
+          guide_id: data.guide_id,
+          key_origin: keyOrigin,
+          card_count: cardCount,
+        });
+
+        controller.enqueue(sseFrame("done", {}));
+        controller.close();
+      } catch (err) {
+        log.error("draft.critique.failed", {
+          request_id: requestId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+        controller.enqueue(
+          sseFrame("error", { message: "critique failed" }),
+        );
+        controller.close();
+      }
+    },
+  });
+
+  return new Response(stream, {
+    status: 200,
+    headers: {
+      "Content-Type": "text/event-stream; charset=utf-8",
+      "Cache-Control": "no-cache, no-transform",
+      "X-Request-Id": requestId,
+    },
+  });
 }

--- a/app/api/interview/turn/route.ts
+++ b/app/api/interview/turn/route.ts
@@ -6,6 +6,7 @@ import { anthropicForKey } from "@/lib/anthropic";
 import { keyOriginTag, readKey } from "@/lib/byo-key/server";
 import { loadBuiltInGuides } from "@/lib/guides/loader";
 import { assemblePrompt } from "@/lib/interview/assemble-prompt";
+import { runAudit } from "@/lib/interview/audit-middleware";
 import { log } from "@/lib/logger";
 import { verbatimOnly } from "@/lib/spine/validate";
 import { FormSchema, ThemeSchema } from "@/lib/types/session";
@@ -274,6 +275,42 @@ async function realResponse(
         });
 
         const finalMessage = await ms.finalMessage();
+
+        // Audit pass — runs after streaming. Log-only by default;
+        // process.env.AUDIT_BLOCK === "1" promotes to blocking. We
+        // still emit `audit_blocked` so the frontend can surface a
+        // warning even though the deltas have already streamed.
+        const assistantText = finalMessage.content
+          .filter(
+            (b): b is Extract<typeof b, { type: "text" }> => b.type === "text",
+          )
+          .map((b) => b.text)
+          .join("");
+        if (assistantText.trim().length > 0) {
+          const audit = await runAudit({
+            message: assistantText,
+            guide,
+            client,
+          });
+          if (audit.flags_tripped.length > 0) {
+            log.warn("interview.turn.audit_flagged", {
+              request_id: requestId,
+              guide_id,
+              flags: audit.flags_tripped,
+              blocked: !audit.allow,
+            });
+          }
+          if (!audit.allow) {
+            controller.enqueue(
+              sseFrame("audit_blocked", {
+                flags_tripped: audit.flags_tripped,
+                reason: audit.reason,
+              }),
+            );
+            controller.close();
+            return;
+          }
+        }
 
         // Surface validated phrases_held from any tool_use blocks.
         for (const block of finalMessage.content) {

--- a/app/api/provenance/route.ts
+++ b/app/api/provenance/route.ts
@@ -1,0 +1,71 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { log } from "@/lib/logger";
+import { matchProvenance } from "@/lib/provenance/match";
+
+export const runtime = "nodejs";
+
+const TurnInputSchema = z.object({
+  id: z.string().min(1),
+  session_id: z.string().min(1).optional(),
+  role: z.enum(["guide", "user"]),
+  text: z.string().max(8000),
+  ts: z.number().int().optional(),
+  phrases_held: z.array(z.string()).optional(),
+});
+
+const Body = z.object({
+  artifact: z.string().max(20000),
+  turns: z.array(TurnInputSchema).max(60),
+});
+
+/**
+ * POST /api/provenance — deterministic provenance matcher.
+ *
+ * Input:  { artifact: string; turns: Turn[] }
+ * Output: { provenance: ProvenanceLine[]; byline_pct: number }
+ *
+ * No model. No key required. Pure compute over the artifact and the
+ * user-typed turns.
+ */
+export async function POST(req: NextRequest): Promise<Response> {
+  const requestId = req.headers.get("x-request-id") ?? crypto.randomUUID();
+
+  let raw: unknown;
+  try {
+    raw = await req.json();
+  } catch {
+    return NextResponse.json(
+      { error: "expected JSON body" },
+      { status: 400 },
+    );
+  }
+
+  const parsed = Body.safeParse(raw);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "invalid body", issues: parsed.error.flatten() },
+      { status: 400 },
+    );
+  }
+
+  // Provide defaults for optional Turn fields the matcher doesn't read.
+  const turns = parsed.data.turns.map((t) => ({
+    id: t.id,
+    session_id: t.session_id ?? "session",
+    role: t.role,
+    text: t.text,
+    ts: t.ts ?? 0,
+    phrases_held: t.phrases_held,
+  }));
+
+  const result = matchProvenance(parsed.data.artifact, turns);
+
+  log.info("provenance.ok", {
+    request_id: requestId,
+    line_count: result.provenance.length,
+    byline_pct: result.byline_pct,
+  });
+
+  return NextResponse.json(result);
+}

--- a/components/App.tsx
+++ b/components/App.tsx
@@ -6,6 +6,7 @@ import { PickMoment } from "./screens/PickMoment";
 import { GuidePicker } from "./screens/GuidePicker";
 import { Interview } from "./screens/Interview";
 import { Spine } from "./screens/Spine";
+import { Drafting } from "./screens/Drafting";
 import { Render } from "./screens/Render";
 import type { Guide } from "@/lib/guides/schema";
 
@@ -21,7 +22,7 @@ export function App({ guides }: { guides: Guide[] }) {
         {step === "guide" && <GuidePicker guides={guides} />}
         {step === "interview" && <Interview />}
         {step === "spine" && <Spine />}
-        {step === "drafting" && <div className="stage text-center">Drafting screen coming soon (Sprint 3).</div>}
+        {step === "drafting" && <Drafting />}
         {step === "render" && <Render />}
       </main>
     </div>

--- a/components/BylineMeter.tsx
+++ b/components/BylineMeter.tsx
@@ -1,0 +1,75 @@
+interface BylineMeterProps {
+  pct: number;
+  lines?: number;
+}
+
+interface Tier {
+  glyph: string;
+  color: string;
+  label: string;
+}
+
+function tierFor(pct: number): Tier {
+  if (pct >= 90) {
+    return { glyph: "✓", color: "var(--t-verified)", label: "verified" };
+  }
+  if (pct >= 70) {
+    return { glyph: "◐", color: "var(--t-highlight)", label: "partial" };
+  }
+  return { glyph: "⚠", color: "var(--t-accent)", label: "low" };
+}
+
+/**
+ * Byline meter — shows the % of artifact words that came verbatim from
+ * the user's interview turns. Color band PLUS iconography per #26
+ * accessibility constraint (not color-only). Uses an aria-label so
+ * screen readers get the full meaning even with the icon hidden.
+ */
+export function BylineMeter({ pct, lines }: BylineMeterProps) {
+  const clamped = Math.max(0, Math.min(100, Math.round(pct)));
+  const t = tierFor(clamped);
+  const linesPart = lines !== undefined ? ` · ${lines} lines` : "";
+
+  return (
+    <div
+      role="status"
+      aria-label={`${clamped} percent verified yours${
+        lines !== undefined ? `, ${lines} lines` : ""
+      } (${t.label})`}
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 8,
+        fontFamily: "var(--t-mono)",
+        fontSize: 11,
+        letterSpacing: "0.14em",
+        textTransform: "uppercase",
+        color: "var(--t-ink-soft)",
+      }}
+    >
+      <span
+        aria-hidden="true"
+        style={{
+          display: "inline-flex",
+          alignItems: "center",
+          justifyContent: "center",
+          width: 18,
+          height: 18,
+          borderRadius: "50%",
+          background: t.color,
+          color: "var(--t-paper)",
+          fontFamily: "var(--t-display)",
+          fontSize: 11,
+          fontWeight: 700,
+          lineHeight: 1,
+        }}
+      >
+        {t.glyph}
+      </span>
+      <span style={{ color: "var(--t-ink)" }}>{clamped}% verified yours</span>
+      {lines !== undefined && (
+        <span style={{ color: "var(--t-ink-faint)" }}>{linesPart}</span>
+      )}
+    </div>
+  );
+}

--- a/components/screens/Drafting.tsx
+++ b/components/screens/Drafting.tsx
@@ -1,0 +1,288 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { getKey } from "@/lib/byo-key";
+import { actions, useAppStore } from "@/lib/store";
+import type { CritiqueCard } from "@/lib/types/session";
+
+export function Drafting() {
+  const [state, dispatch] = useAppStore();
+  const { draft, theme, turns, artifact_text } = state;
+  const [draftText, setDraftText] = useState(artifact_text);
+  const [cards, setCards] = useState<CritiqueCard[]>([]);
+  const [isStreaming, setIsStreaming] = useState(false);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const cancelRef = useRef<AbortController | null>(null);
+
+  // Sync local edits up to the store so Render can pick them up.
+  useEffect(() => {
+    dispatch(actions.setArtifactText(draftText));
+  }, [draftText, dispatch]);
+
+  const fetchCritique = useCallback(
+    async (text: string) => {
+      if (!text.trim() || !draft.guide_id) return;
+      // Cancel any in-flight critique
+      cancelRef.current?.abort();
+      const controller = new AbortController();
+      cancelRef.current = controller;
+      setIsStreaming(true);
+      setCards([]);
+
+      try {
+        const byoKey = getKey();
+        const res = await fetch("/api/draft/critique", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            ...(byoKey ? { "X-Anthropic-Key": byoKey } : {}),
+          },
+          body: JSON.stringify({
+            draft: text,
+            turns: turns.map((t) => ({
+              id: t.id,
+              role: t.role,
+              text: t.text,
+            })),
+            guide_id: draft.guide_id,
+            theme,
+          }),
+          signal: controller.signal,
+        });
+
+        if (!res.ok) return;
+
+        const ct = res.headers.get("Content-Type") ?? "";
+        if (!ct.includes("text/event-stream")) {
+          // Stub mode JSON
+          const json = (await res.json()) as { cards?: CritiqueCard[] };
+          setCards(json.cards ?? []);
+          return;
+        }
+
+        // Real-mode SSE
+        const reader = res.body?.getReader();
+        if (!reader) return;
+        const decoder = new TextDecoder();
+        let buffer = "";
+        const collected: CritiqueCard[] = [];
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          buffer += decoder.decode(value, { stream: true });
+          let boundary = buffer.indexOf("\n\n");
+          while (boundary !== -1) {
+            const frame = buffer.slice(0, boundary);
+            buffer = buffer.slice(boundary + 2);
+            boundary = buffer.indexOf("\n\n");
+            if (!frame.trim()) continue;
+            let event = "message";
+            let data = "";
+            for (const line of frame.split("\n")) {
+              if (line.startsWith("event:")) event = line.slice(6).trim();
+              else if (line.startsWith("data:")) data = line.slice(5).trim();
+            }
+            if (event === "card") {
+              try {
+                const card = JSON.parse(data) as CritiqueCard;
+                collected.push(card);
+                setCards([...collected]);
+              } catch {
+                // malformed frame — skip
+              }
+            }
+          }
+        }
+      } catch (err) {
+        // AbortError is expected on debounce; swallow it. Other errors
+        // we ignore for now — the right pane just stays empty.
+        if ((err as Error).name !== "AbortError") {
+          // no-op for v1
+        }
+      } finally {
+        setIsStreaming(false);
+      }
+    },
+    [draft.guide_id, turns, theme],
+  );
+
+  // Debounced critique fetch — fire 600ms after the user stops typing.
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    if (!draftText.trim()) return;
+    debounceRef.current = setTimeout(() => {
+      void fetchCritique(draftText);
+    }, 600);
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [draftText, fetchCritique]);
+
+  if (!draft.guide_id) {
+    return (
+      <div className="stage">
+        <div className="eyebrow">drafting</div>
+        <h1 className="h-display tiny" style={{ marginTop: 12 }}>
+          Pick a guide first.
+        </h1>
+        <button
+          className="btn primary"
+          style={{ marginTop: 16 }}
+          onClick={() => dispatch(actions.setStep("guide"))}
+        >
+          back to guide picker →
+        </button>
+      </div>
+    );
+  }
+
+  const wordCount = draftText.split(/\s+/).filter(Boolean).length;
+
+  return (
+    <div className="stage" style={{ maxWidth: 1180 }}>
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          marginBottom: 22,
+        }}
+      >
+        <div className="eyebrow">drafting · {draft.guide_id}</div>
+        <span
+          className="muted"
+          style={{ fontFamily: "var(--t-mono)", fontSize: 10 }}
+        >
+          {wordCount} words
+        </span>
+      </div>
+
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "1.5fr 1fr",
+          gap: 48,
+          alignItems: "start",
+        }}
+      >
+        {/* LEFT — editor */}
+        <div>
+          <div className="eyebrow" style={{ marginBottom: 10 }}>
+            your draft · take your time
+          </div>
+          <textarea
+            className="textarea-prose"
+            value={draftText}
+            onChange={(e) => setDraftText(e.target.value)}
+            rows={20}
+            placeholder="start with one of your phrases. let the rest follow."
+            style={{ fontSize: 19, minHeight: 480, lineHeight: 1.7 }}
+          />
+          <div
+            style={{
+              display: "flex",
+              justifyContent: "flex-end",
+              marginTop: 14,
+            }}
+          >
+            <button
+              className="btn primary"
+              onClick={() => dispatch(actions.setStep("render"))}
+              disabled={draftText.trim().length < 20}
+              style={{
+                opacity: draftText.trim().length < 20 ? 0.4 : 1,
+              }}
+            >
+              render the artifact →
+            </button>
+          </div>
+        </div>
+
+        {/* RIGHT — critique stream */}
+        <div>
+          <div
+            className="eyebrow"
+            style={{ marginBottom: 10, display: "flex", alignItems: "center", gap: 8 }}
+          >
+            <span>guide · just notes</span>
+            {isStreaming && (
+              <span
+                className="muted"
+                style={{ fontFamily: "var(--t-mono)", fontSize: 10 }}
+              >
+                · listening
+              </span>
+            )}
+          </div>
+          {cards.length === 0 && !isStreaming && (
+            <div
+              className="muted"
+              style={{
+                fontFamily: "var(--t-mono)",
+                fontSize: 11,
+                padding: 12,
+              }}
+            >
+              start writing — the guide will read alongside.
+            </div>
+          )}
+          <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+            {cards.map((card, i) => {
+              const accent =
+                card.kind === "cliche"
+                  ? "var(--t-accent)"
+                  : card.kind === "verified"
+                    ? "var(--t-verified)"
+                    : "var(--t-ink-soft)";
+              const labelText =
+                card.kind === "cliche"
+                  ? "⚠ cliché · borrowed phrase"
+                  : card.kind === "verified"
+                    ? "✓ verified yours"
+                    : "? noticing";
+              return (
+                <div
+                  key={i}
+                  className="card outlined"
+                  style={{
+                    padding: "12px 16px",
+                    borderLeft: `2px solid ${accent}`,
+                    animation: "fadein 400ms ease",
+                  }}
+                >
+                  <div className="eyebrow" style={{ color: accent }}>
+                    {labelText}
+                  </div>
+                  {card.line_ref && (
+                    <div
+                      className="serif-italic"
+                      style={{
+                        fontSize: 14,
+                        fontStyle: "italic",
+                        marginTop: 4,
+                        color: "var(--t-ink)",
+                      }}
+                    >
+                      &ldquo;{card.line_ref}&rdquo;
+                    </div>
+                  )}
+                  <div
+                    style={{
+                      fontFamily: "var(--t-body)",
+                      fontSize: 14,
+                      marginTop: 6,
+                      color: "var(--t-ink-soft)",
+                      lineHeight: 1.5,
+                    }}
+                  >
+                    {card.body}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/screens/Render.tsx
+++ b/components/screens/Render.tsx
@@ -1,34 +1,95 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { BylineMeter } from "@/components/BylineMeter";
 import { SCRIPT } from "@/lib/demo";
 import { actions, useAppStore } from "@/lib/store";
+import type { ProvenanceLine } from "@/lib/types/session";
 
-interface HoveredLine {
-  text: string;
-  src: string;
-  q: string;
-  a: string;
+interface ProvenanceResponse {
+  provenance: ProvenanceLine[];
+  byline_pct: number;
+}
+
+interface RenderLine {
+  line: string;
+  src_id: string;
+  question: string | null;
+  answer: string | null;
+  match: "exact" | "fuzzy" | "none";
 }
 
 export function Render() {
-  const [, dispatch] = useAppStore();
-  const [hovered, setHovered] = useState<HoveredLine | null>(null);
+  const [state, dispatch] = useAppStore();
+  const { artifact_text, turns } = state;
+  const [hovered, setHovered] = useState<RenderLine | null>(null);
   const [pos, setPos] = useState({ x: 0, y: 0 });
+  const [real, setReal] = useState<ProvenanceResponse | null>(null);
 
   useEffect(() => {
     dispatch(actions.setEmotion("hopeful"));
   }, [dispatch]);
 
-  // Final lines: the cliché was cut during drafting.
-  const finalLines = SCRIPT.draft.filter((d) => d.verified);
+  // Fetch real provenance when we have a drafted artifact + turns.
+  useEffect(() => {
+    if (!artifact_text.trim() || turns.length === 0) {
+      setReal(null);
+      return;
+    }
+    let cancelled = false;
+    fetch("/api/provenance", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        artifact: artifact_text,
+        turns: turns.map((t) => ({ id: t.id, role: t.role, text: t.text })),
+      }),
+    })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data: ProvenanceResponse | null) => {
+        if (!cancelled && data) setReal(data);
+      })
+      .catch(() => {
+        // swallow — falls through to the SCRIPT-driven demo trace.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [artifact_text, turns]);
 
-  // Map "q3" -> SCRIPT.interview[2].
-  const lineToQA = (src: string | null) => {
-    if (!src) return null;
-    const idx = parseInt(src.replace(/^q/, ""), 10) - 1;
-    return SCRIPT.interview[idx] ?? null;
-  };
+  const useReal = real !== null && artifact_text.trim().length > 0;
+
+  const finalLines: RenderLine[] = useReal
+    ? real!.provenance
+        .filter((p) => p.line.trim().length > 0)
+        .map((p) => {
+          const turn = turns.find((t) => t.id === p.source_turn_id);
+          const turnIdx = turn ? turns.indexOf(turn) : -1;
+          const guideTurn = turnIdx > 0 ? turns[turnIdx - 1] : null;
+          return {
+            line: p.line.trim(),
+            src_id: p.source_turn_id,
+            question:
+              guideTurn?.role === "guide" ? guideTurn.text : null,
+            answer: turn?.text ?? p.source_text,
+            match: p.match,
+          };
+        })
+    : SCRIPT.draft
+        .filter((d) => d.verified)
+        .map((d) => {
+          const idx = d.src ? parseInt(d.src.replace(/^q/, ""), 10) - 1 : -1;
+          const qa = idx >= 0 ? SCRIPT.interview[idx] : null;
+          return {
+            line: d.text,
+            src_id: d.src ?? "",
+            question: qa?.q ?? null,
+            answer: qa?.a ?? null,
+            match: "exact" as const,
+          };
+        });
+
+  const bylinePct = useReal ? real!.byline_pct : 100;
 
   return (
     <div
@@ -38,13 +99,17 @@ export function Render() {
       <div className="corner-stamp">
         <div className="postmark">
           <div className="pm-top">verified · yours</div>
-          <div className="pm-mid">100%</div>
-          <div className="pm-bot">mean it · 2025</div>
+          <div className="pm-mid">{bylinePct}%</div>
+          <div className="pm-bot">mean it · 2026</div>
         </div>
       </div>
 
       <div style={{ textAlign: "center", marginBottom: 36 }}>
-        <div className="eyebrow">for tomas · read aloud, saturday</div>
+        <div className="eyebrow">
+          {useReal
+            ? "your artifact · read it aloud"
+            : "for tomas · read aloud, saturday"}
+        </div>
         <div className="ornament" style={{ marginTop: 12 }}>
           <svg
             width={120}
@@ -73,29 +138,38 @@ export function Render() {
         }}
       >
         {finalLines.map((ln, i) => {
-          const qa = lineToQA(ln.src);
+          const interactive =
+            ln.match !== "none" && (ln.question !== null || ln.answer !== null);
           return (
             <div
               key={i}
               className="trace-line"
+              tabIndex={interactive ? 0 : -1}
               style={{
                 marginBottom: i === finalLines.length - 2 ? 18 : 4,
+                cursor: interactive ? "help" : "default",
+                opacity: ln.match === "none" ? 0.6 : 1,
               }}
               onMouseEnter={(e) => {
-                if (qa && ln.src) {
-                  setHovered({
-                    text: ln.text,
-                    src: ln.src,
-                    q: qa.q,
-                    a: qa.a,
-                  });
+                if (interactive) {
+                  setHovered(ln);
                   setPos({ x: e.clientX, y: e.clientY });
                 }
               }}
               onMouseMove={(e) => setPos({ x: e.clientX, y: e.clientY })}
               onMouseLeave={() => setHovered(null)}
+              onFocus={(e) => {
+                if (interactive) {
+                  setHovered(ln);
+                  const rect = (
+                    e.target as HTMLElement
+                  ).getBoundingClientRect();
+                  setPos({ x: rect.right, y: rect.top + rect.height / 2 });
+                }
+              }}
+              onBlur={() => setHovered(null)}
             >
-              {ln.text}
+              {ln.line}
             </div>
           );
         })}
@@ -110,8 +184,9 @@ export function Render() {
           display: "flex",
           justifyContent: "center",
           alignItems: "center",
-          gap: 14,
+          gap: 18,
           marginBottom: 8,
+          flexWrap: "wrap",
         }}
       >
         <div className="seal" style={{ width: 44, height: 44 }}>
@@ -119,12 +194,7 @@ export function Render() {
             M
           </span>
         </div>
-        <div
-          className="serif-italic"
-          style={{ fontSize: 22, color: "var(--t-ink)" }}
-        >
-          One hundred percent your words.
-        </div>
+        <BylineMeter pct={bylinePct} lines={finalLines.length} />
       </div>
       <div
         className="muted"
@@ -176,6 +246,7 @@ export function Render() {
       {hovered && (
         <div
           className="trace-pop"
+          role="tooltip"
           style={{
             left: Math.min(
               pos.x + 16,
@@ -185,44 +256,56 @@ export function Render() {
           }}
         >
           <div className="eyebrow" style={{ color: "var(--t-accent)" }}>
-            trace · {hovered.src}
+            trace · {hovered.match}
           </div>
-          <div
-            className="muted"
-            style={{
-              fontFamily: "var(--t-mono)",
-              fontSize: 9,
-              marginTop: 8,
-            }}
-          >
-            question
-          </div>
-          <div
-            className="serif-italic"
-            style={{ fontSize: 14, marginTop: 2, color: "var(--t-ink)" }}
-          >
-            &ldquo;{hovered.q}&rdquo;
-          </div>
-          <div
-            className="muted"
-            style={{
-              fontFamily: "var(--t-mono)",
-              fontSize: 9,
-              marginTop: 10,
-            }}
-          >
-            your verbatim answer
-          </div>
-          <div
-            style={{
-              fontSize: 13,
-              marginTop: 4,
-              color: "var(--t-ink-soft)",
-              fontStyle: "italic",
-            }}
-          >
-            &ldquo;{hovered.a}&rdquo;
-          </div>
+          {hovered.question && (
+            <>
+              <div
+                className="muted"
+                style={{
+                  fontFamily: "var(--t-mono)",
+                  fontSize: 9,
+                  marginTop: 8,
+                }}
+              >
+                question
+              </div>
+              <div
+                className="serif-italic"
+                style={{
+                  fontSize: 14,
+                  marginTop: 2,
+                  color: "var(--t-ink)",
+                }}
+              >
+                &ldquo;{hovered.question}&rdquo;
+              </div>
+            </>
+          )}
+          {hovered.answer && (
+            <>
+              <div
+                className="muted"
+                style={{
+                  fontFamily: "var(--t-mono)",
+                  fontSize: 9,
+                  marginTop: 10,
+                }}
+              >
+                your verbatim answer
+              </div>
+              <div
+                style={{
+                  fontSize: 13,
+                  marginTop: 4,
+                  color: "var(--t-ink-soft)",
+                  fontStyle: "italic",
+                }}
+              >
+                &ldquo;{hovered.answer}&rdquo;
+              </div>
+            </>
+          )}
           <div
             style={{
               marginTop: 12,
@@ -235,7 +318,11 @@ export function Render() {
               textTransform: "uppercase",
             }}
           >
-            ✓ exact substring · verified yours
+            {hovered.match === "exact"
+              ? "✓ exact substring · verified yours"
+              : hovered.match === "fuzzy"
+                ? "◐ close paraphrase · within 2 edits"
+                : "⚠ no source match"}
           </div>
         </div>
       )}

--- a/lib/interview/audit-middleware.ts
+++ b/lib/interview/audit-middleware.ts
@@ -1,0 +1,115 @@
+import type Anthropic from "@anthropic-ai/sdk";
+import type { Guide } from "@/lib/guides/schema";
+
+export interface RunAuditInput {
+  message: string;
+  guide: Guide;
+  client: Anthropic;
+}
+
+export interface AuditResult {
+  allow: boolean;
+  flags_tripped: string[];
+  reason: string;
+}
+
+/**
+ * Audit an assistant message against the active guide's audit_flags.
+ *
+ * - Default mode is log-only: `allow` is always true, but the caller is
+ *   expected to log the result so a human can inspect false positives.
+ * - When `process.env.AUDIT_BLOCK === "1"` and at least one flag tripped,
+ *   `allow` is false. The caller is responsible for surfacing this to
+ *   the client (e.g. an `audit_blocked` SSE event).
+ *
+ * Infra failures (network, model error) yield `allow: true` with empty
+ * flags. We never block on a failed audit — that would let an outage
+ * become a denial-of-service for the whole interview flow.
+ */
+export async function runAudit(input: RunAuditInput): Promise<AuditResult> {
+  const flagDescriptions = input.guide.audit_flags
+    .map((f) => `- ${f.name}: ${f.description}`)
+    .join("\n");
+
+  const systemText = [
+    "You audit assistant messages produced by a creative-guide app.",
+    "The guide is FORBIDDEN from drafting the user's artifact.",
+    "Inspect the message below and report which audit flags it trips.",
+    "",
+    `AUDIT FLAGS for guide ${input.guide.name}:`,
+    flagDescriptions,
+    "",
+    'If the message is clean, return flags_tripped=[] and reason="".',
+    "If any flags fire, list them and explain in one sentence which",
+    "passage(s) triggered each.",
+    "",
+    "Use the record_audit tool for the response.",
+  ].join("\n");
+
+  const tools: Anthropic.Tool[] = [
+    {
+      name: "record_audit",
+      description: "Record which audit flags this message trips, if any.",
+      input_schema: {
+        type: "object" as const,
+        properties: {
+          flags_tripped: {
+            type: "array",
+            items: { type: "string" },
+            description: "Names of flags that fired. Empty if clean.",
+          },
+          reason: {
+            type: "string",
+            description: "One-sentence explanation. Empty if no flags fired.",
+          },
+        },
+        required: ["flags_tripped", "reason"],
+      },
+    },
+  ];
+
+  try {
+    const result = await input.client.messages.create({
+      model: "claude-haiku-4-5-20251001",
+      max_tokens: 256,
+      system: [
+        {
+          type: "text",
+          text: systemText,
+          cache_control: { type: "ephemeral" },
+        },
+      ],
+      messages: [
+        {
+          role: "user",
+          content: `Message:\n\n${input.message}\n\nRun the audit.`,
+        },
+      ],
+      tools,
+      tool_choice: { type: "tool", name: "record_audit" },
+    });
+
+    let flags: string[] = [];
+    let reason = "";
+    for (const block of result.content) {
+      if (block.type === "tool_use" && block.name === "record_audit") {
+        const i = block.input as {
+          flags_tripped?: unknown;
+          reason?: unknown;
+        };
+        flags = Array.isArray(i.flags_tripped)
+          ? (i.flags_tripped as unknown[]).filter(
+              (x): x is string => typeof x === "string",
+            )
+          : [];
+        reason = typeof i.reason === "string" ? i.reason : "";
+      }
+    }
+
+    const blocked =
+      process.env.AUDIT_BLOCK === "1" && flags.length > 0;
+    return { allow: !blocked, flags_tripped: flags, reason };
+  } catch {
+    return { allow: true, flags_tripped: [], reason: "" };
+  }
+}

--- a/lib/provenance/match.ts
+++ b/lib/provenance/match.ts
@@ -1,0 +1,146 @@
+import type { ProvenanceLine, Turn } from "@/lib/types/session";
+
+export interface ProvenanceMatchResult {
+  provenance: ProvenanceLine[];
+  byline_pct: number;
+}
+
+/**
+ * Deterministic provenance matcher. For each line of `artifact`, decide:
+ *
+ * - `'exact'` — line is a verbatim substring of one of the user's turns.
+ * - `'fuzzy'` — line approximately matches a window of words in a turn,
+ *   with each word within 2 edits of its counterpart (Levenshtein).
+ * - `'none'` — neither (paraphrase or fabrication).
+ *
+ * `byline_pct = (verified_words / total_words) * 100`, where verified =
+ * exact + fuzzy. Blank lines are recorded as `'none'` but contribute zero
+ * to both numerator and denominator.
+ *
+ * Only `role: 'user'` turns are considered as sources — guide turns are
+ * the questions, not the user's words.
+ */
+export function matchProvenance(
+  artifact: string,
+  turns: ReadonlyArray<Turn>,
+): ProvenanceMatchResult {
+  const userTurns = turns.filter((t) => t.role === "user");
+  const lines = artifact.split("\n");
+  const provenance: ProvenanceLine[] = [];
+  let totalWords = 0;
+  let verifiedWords = 0;
+
+  for (const rawLine of lines) {
+    const line = rawLine.trim();
+    if (!line) {
+      provenance.push({
+        line: rawLine,
+        source_turn_id: "",
+        source_text: "",
+        match: "none",
+      });
+      continue;
+    }
+
+    const wordCount = line.split(/\s+/).filter(Boolean).length;
+    totalWords += wordCount;
+
+    let matched: ProvenanceLine | null = null;
+    for (const turn of userTurns) {
+      if (turn.text.includes(line)) {
+        matched = {
+          line: rawLine,
+          source_turn_id: turn.id,
+          source_text: turn.text,
+          match: "exact",
+        };
+        break;
+      }
+    }
+
+    if (!matched) {
+      for (const turn of userTurns) {
+        if (fuzzyContains(line, turn.text)) {
+          matched = {
+            line: rawLine,
+            source_turn_id: turn.id,
+            source_text: turn.text,
+            match: "fuzzy",
+          };
+          break;
+        }
+      }
+    }
+
+    if (matched) {
+      provenance.push(matched);
+      verifiedWords += wordCount;
+    } else {
+      provenance.push({
+        line: rawLine,
+        source_turn_id: "",
+        source_text: "",
+        match: "none",
+      });
+    }
+  }
+
+  const byline_pct =
+    totalWords > 0 ? Math.round((verifiedWords / totalWords) * 100) : 0;
+
+  return { provenance, byline_pct };
+}
+
+/**
+ * True when `haystack` contains a window of words that approximately
+ * matches `needle` — each word within 2 Levenshtein edits.
+ */
+function fuzzyContains(needle: string, haystack: string): boolean {
+  const needleWords = needle.split(/\s+/).filter(Boolean);
+  const hayWords = haystack.split(/\s+/).filter(Boolean);
+  if (needleWords.length === 0 || hayWords.length === 0) return false;
+  if (needleWords.length > hayWords.length) return false;
+
+  for (let i = 0; i + needleWords.length <= hayWords.length; i++) {
+    let allMatch = true;
+    for (let j = 0; j < needleWords.length; j++) {
+      const a = needleWords[j]!;
+      const b = hayWords[i + j]!;
+      if (Math.abs(a.length - b.length) > 2) {
+        allMatch = false;
+        break;
+      }
+      if (levenshtein(a, b) > 2) {
+        allMatch = false;
+        break;
+      }
+    }
+    if (allMatch) return true;
+  }
+  return false;
+}
+
+function levenshtein(a: string, b: string): number {
+  const m = a.length;
+  const n = b.length;
+  if (m === 0) return n;
+  if (n === 0) return m;
+
+  let prev = new Array<number>(n + 1);
+  let curr = new Array<number>(n + 1);
+  for (let j = 0; j <= n; j++) prev[j] = j;
+
+  for (let i = 1; i <= m; i++) {
+    curr[0] = i;
+    for (let j = 1; j <= n; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      curr[j] = Math.min(
+        curr[j - 1]! + 1,
+        prev[j]! + 1,
+        prev[j - 1]! + cost,
+      );
+    }
+    [prev, curr] = [curr, prev];
+  }
+  return prev[n]!;
+}

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -56,6 +56,10 @@ export interface AppState {
   // if absent.
   session_id: string;
   turns: Turn[];
+  // artifact_text is the user's draft prose (Drafting screen output ↔
+  // Render screen input). Empty string = not yet drafted; Render falls
+  // back to the demo SCRIPT in that case.
+  artifact_text: string;
 }
 
 export type Action =
@@ -67,6 +71,7 @@ export type Action =
   | { type: "patch_draft"; patch: Partial<DraftSession> }
   | { type: "set_session_id"; session_id: string }
   | { type: "append_turn"; turn: Turn }
+  | { type: "set_artifact_text"; text: string }
   | { type: "reset" };
 
 const STEPS: readonly Step[] = STEPS_TUPLE;
@@ -90,6 +95,7 @@ const PersistedSchema = z.object({
   draft: DraftSchema,
   session_id: z.string().default(""),
   turns: z.array(TurnSchema).default([]),
+  artifact_text: z.string().default(""),
 });
 
 export const INITIAL_STATE: AppState = {
@@ -105,6 +111,7 @@ export const INITIAL_STATE: AppState = {
   },
   session_id: "",
   turns: [],
+  artifact_text: "",
 };
 
 export function reducer(state: AppState, action: Action): AppState {
@@ -128,6 +135,8 @@ export function reducer(state: AppState, action: Action): AppState {
       return { ...state, session_id: action.session_id };
     case "append_turn":
       return { ...state, turns: [...state.turns, action.turn] };
+    case "set_artifact_text":
+      return { ...state, artifact_text: action.text };
     case "reset":
       return INITIAL_STATE;
   }
@@ -183,5 +192,9 @@ export const actions = {
     session_id,
   }),
   appendTurn: (turn: Turn): Action => ({ type: "append_turn", turn }),
+  setArtifactText: (text: string): Action => ({
+    type: "set_artifact_text",
+    text,
+  }),
   reset: (): Action => ({ type: "reset" }),
 };

--- a/tests/api/audit.test.ts
+++ b/tests/api/audit.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { NextRequest } from "next/server";
+
+const mockCreate = vi.hoisted(() => vi.fn());
+
+vi.mock("@anthropic-ai/sdk", () => ({
+  default: vi.fn().mockImplementation(() => ({
+    messages: {
+      create: mockCreate,
+      stream: vi.fn(),
+    },
+  })),
+}));
+
+const { POST } = await import("@/app/api/audit/route");
+
+function makeRequest(
+  body: object | null,
+  headers: Record<string, string> = {},
+): NextRequest {
+  return new Request("http://localhost/api/audit", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...headers },
+    body: body === null ? "" : JSON.stringify(body),
+  }) as unknown as NextRequest;
+}
+
+const auditResponse = (flags: string[], reason: string) => ({
+  content: [
+    {
+      type: "tool_use",
+      name: "record_audit",
+      input: { flags_tripped: flags, reason },
+    },
+  ],
+});
+
+const byoHeaders = { "X-Anthropic-Key": "sk-ant-test" };
+const baseBody = {
+  message: "What did she say when she answered the phone?",
+  guide_id: "documentarian",
+};
+
+beforeEach(() => mockCreate.mockReset());
+
+afterEach(() => {
+  delete process.env.AUDIT_BLOCK;
+});
+
+describe("POST /api/audit — stub mode", () => {
+  it("returns empty flags when no key is provided", async () => {
+    const res = await POST(makeRequest(baseBody));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.stub).toBe(true);
+    expect(json.flags_tripped).toEqual([]);
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /api/audit — real mode (Haiku mocked)", () => {
+  it("returns empty flags on a clean message", async () => {
+    mockCreate.mockResolvedValueOnce(auditResponse([], ""));
+    const res = await POST(makeRequest(baseBody, byoHeaders));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.flags_tripped).toEqual([]);
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns flags + reason when the model finds a violation", async () => {
+    mockCreate.mockResolvedValueOnce(
+      auditResponse(
+        ["drafted_line"],
+        "the third sentence is a poetic line in the artifact's register.",
+      ),
+    );
+    const res = await POST(makeRequest(baseBody, byoHeaders));
+    const json = await res.json();
+    expect(json.flags_tripped).toEqual(["drafted_line"]);
+    expect(json.reason).toContain("third sentence");
+  });
+
+  it("404s on an unknown guide_id", async () => {
+    const res = await POST(
+      makeRequest({ ...baseBody, guide_id: "ghost-xyz" }, byoHeaders),
+    );
+    expect(res.status).toBe(404);
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it("400s on a malformed body", async () => {
+    const res = await POST(
+      makeRequest({ message: "" } as unknown as object, byoHeaders),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("400s on non-JSON body", async () => {
+    const res = await POST(makeRequest(null, byoHeaders));
+    expect(res.status).toBe(400);
+  });
+});

--- a/tests/api/draft-critique-real.test.ts
+++ b/tests/api/draft-critique-real.test.ts
@@ -1,0 +1,147 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { NextRequest } from "next/server";
+
+const sse = vi.hoisted(() => {
+  const finalMessageMock = vi.fn();
+  const mockStream = {
+    on() {
+      return mockStream;
+    },
+    finalMessage() {
+      return finalMessageMock();
+    },
+  };
+  const reset = () => {
+    finalMessageMock.mockReset();
+  };
+  return { mockStream, finalMessageMock, reset };
+});
+
+vi.mock("@anthropic-ai/sdk", () => ({
+  default: vi.fn().mockImplementation(() => ({
+    messages: {
+      stream: vi.fn().mockReturnValue(sse.mockStream),
+      create: vi.fn(),
+    },
+  })),
+}));
+
+const { POST } = await import("@/app/api/draft/critique/route");
+
+function makeRequest(
+  body: object,
+  headers: Record<string, string> = {},
+): NextRequest {
+  return new Request("http://localhost/api/draft/critique", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...headers },
+    body: JSON.stringify(body),
+  }) as unknown as NextRequest;
+}
+
+const baseBody = {
+  draft: "Tomas kept a notebook in his coat pocket.",
+  turns: [
+    { id: "u1", role: "user", text: "He kept a notebook in his coat pocket." },
+  ],
+  guide_id: "documentarian",
+  theme: "quiet",
+};
+const byoHeaders = { "X-Anthropic-Key": "sk-ant-test" };
+
+const cardBlock = (
+  kind: "cliche" | "question" | "verified",
+  body: string,
+  line_ref?: string,
+) => ({
+  type: "tool_use",
+  name: "record_critique_card",
+  input: { kind, body, ...(line_ref ? { line_ref } : {}) },
+});
+
+beforeEach(() => sse.reset());
+
+describe("POST /api/draft/critique — real mode", () => {
+  it("emits one card SSE event per record_critique_card tool call, then done", async () => {
+    sse.finalMessageMock.mockResolvedValue({
+      content: [
+        cardBlock("cliche", "stock phrase noticed", "forever in our hearts"),
+        cardBlock(
+          "verified",
+          "lifted from your turn — keep it.",
+          "kept a notebook in his coat pocket",
+        ),
+        cardBlock("question", "did you mean simpler or quieter?", "simpler"),
+      ],
+      usage: { input_tokens: 100, output_tokens: 30 },
+    });
+
+    const res = await POST(makeRequest(baseBody, byoHeaders));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toContain("text/event-stream");
+
+    const text = await res.text();
+    // Three card events
+    const cardCount = (text.match(/event: card/g) ?? []).length;
+    expect(cardCount).toBe(3);
+    expect(text).toContain("stock phrase noticed");
+    expect(text).toContain("lifted from your turn");
+    expect(text).toContain("did you mean simpler");
+    // done at the end
+    expect(text).toContain("event: done");
+    expect(text.lastIndexOf("event: done")).toBeGreaterThan(
+      text.lastIndexOf("event: card"),
+    );
+  });
+
+  it("skips invalid tool inputs", async () => {
+    sse.finalMessageMock.mockResolvedValue({
+      content: [
+        cardBlock("cliche", "valid card", "x"),
+        // Invalid kind — should be dropped
+        {
+          type: "tool_use",
+          name: "record_critique_card",
+          input: { kind: "nonsense", body: "should be skipped" },
+        },
+      ],
+      usage: { input_tokens: 50, output_tokens: 10 },
+    });
+
+    const res = await POST(makeRequest(baseBody, byoHeaders));
+    const text = await res.text();
+    const cardCount = (text.match(/event: card/g) ?? []).length;
+    expect(cardCount).toBe(1);
+    expect(text).toContain("valid card");
+    expect(text).not.toContain("should be skipped");
+  });
+
+  it("emits done with no cards when the model produces no tool calls", async () => {
+    sse.finalMessageMock.mockResolvedValue({
+      content: [{ type: "text", text: "Hmm, draft looks clean." }],
+      usage: { input_tokens: 30, output_tokens: 5 },
+    });
+
+    const res = await POST(makeRequest(baseBody, byoHeaders));
+    const text = await res.text();
+    expect(text).not.toContain("event: card");
+    expect(text).toContain("event: done");
+  });
+
+  it("404s on an unknown guide_id", async () => {
+    const res = await POST(
+      makeRequest({ ...baseBody, guide_id: "ghost-xyz" }, byoHeaders),
+    );
+    expect(res.status).toBe(404);
+    expect(sse.finalMessageMock).not.toHaveBeenCalled();
+  });
+
+  it("emits error frame when the SDK throws", async () => {
+    sse.finalMessageMock.mockRejectedValue(new Error("rate limited"));
+
+    const res = await POST(makeRequest(baseBody, byoHeaders));
+    const text = await res.text();
+    expect(text).toContain("event: error");
+    expect(text).toContain("critique failed");
+  });
+});

--- a/tests/api/draft-critique.test.ts
+++ b/tests/api/draft-critique.test.ts
@@ -1,5 +1,29 @@
-import { describe, expect, it } from "vitest";
-import { POST } from "@/app/api/draft/critique/route";
+import { describe, expect, it, vi } from "vitest";
+
+// The route enters real-Sonnet mode whenever a key is present (BYO header
+// or env). Some of these tests send a BYO header to assert that the key
+// doesn't leak — without a mock here those would make real Anthropic
+// calls. Mock returns a benign empty-card response so the real-mode
+// branch completes cleanly without network IO.
+vi.mock("@anthropic-ai/sdk", () => ({
+  default: vi.fn().mockImplementation(() => ({
+    messages: {
+      stream: vi.fn().mockReturnValue({
+        on() {
+          return this;
+        },
+        finalMessage: () =>
+          Promise.resolve({
+            content: [],
+            usage: { input_tokens: 0, output_tokens: 0 },
+          }),
+      }),
+      create: vi.fn(),
+    },
+  })),
+}));
+
+const { POST } = await import("@/app/api/draft/critique/route");
 
 function jsonRequest(body: unknown, headers: Record<string, string> = {}): Request {
   return new Request("http://localhost/api/draft/critique", {

--- a/tests/api/provenance.test.ts
+++ b/tests/api/provenance.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import type { NextRequest } from "next/server";
+import { POST } from "@/app/api/provenance/route";
+
+function makeRequest(body: unknown, raw = false): NextRequest {
+  return new Request("http://localhost/api/provenance", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: raw ? (body as string) : JSON.stringify(body),
+  }) as unknown as NextRequest;
+}
+
+describe("POST /api/provenance", () => {
+  it("returns provenance + byline_pct on a valid request", async () => {
+    const res = await POST(
+      makeRequest({
+        artifact: "Hello world",
+        turns: [
+          {
+            id: "u1",
+            session_id: "s",
+            role: "user",
+            text: "Hello world is what I said.",
+            ts: 1,
+          },
+        ],
+      }),
+    );
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as {
+      provenance: Array<{ match: string }>;
+      byline_pct: number;
+    };
+    expect(json.provenance[0]!.match).toBe("exact");
+    expect(json.byline_pct).toBe(100);
+  });
+
+  it("400s on a malformed body", async () => {
+    const res = await POST(
+      makeRequest({ artifact: "x" /* missing turns */ }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("400s on non-JSON body", async () => {
+    const res = await POST(makeRequest("not json", true));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns byline_pct 0 with empty turns", async () => {
+    const res = await POST(
+      makeRequest({ artifact: "anything goes", turns: [] }),
+    );
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { byline_pct: number };
+    expect(json.byline_pct).toBe(0);
+  });
+
+  it("accepts turns with optional fields omitted", async () => {
+    const res = await POST(
+      makeRequest({
+        artifact: "Hello",
+        turns: [{ id: "u1", role: "user", text: "Hello and goodbye." }],
+      }),
+    );
+    expect(res.status).toBe(200);
+  });
+});

--- a/tests/components/BylineMeter.test.ts
+++ b/tests/components/BylineMeter.test.ts
@@ -1,0 +1,62 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { BylineMeter } from "@/components/BylineMeter";
+
+const render = (props: { pct: number; lines?: number }) =>
+  renderToStaticMarkup(createElement(BylineMeter, props));
+
+describe("BylineMeter", () => {
+  it("shows the verified glyph at 90 and above", () => {
+    const html = render({ pct: 95 });
+    expect(html).toContain("✓");
+    expect(html).toContain("var(--t-verified)");
+    expect(html).toContain("95% verified yours");
+  });
+
+  it("shows the partial glyph at 70-89", () => {
+    const html = render({ pct: 80 });
+    expect(html).toContain("◐");
+    expect(html).toContain("var(--t-highlight)");
+  });
+
+  it("shows the warning glyph below 70", () => {
+    const html = render({ pct: 45 });
+    expect(html).toContain("⚠");
+    expect(html).toContain("var(--t-accent)");
+  });
+
+  it("clamps out-of-range values to [0, 100]", () => {
+    const high = render({ pct: 150 });
+    expect(high).toContain("100% verified yours");
+    const low = render({ pct: -10 });
+    expect(low).toContain("0% verified yours");
+  });
+
+  it("rounds non-integer percentages", () => {
+    const html = render({ pct: 87.6 });
+    expect(html).toContain("88% verified yours");
+  });
+
+  it("emits an aria-label that includes the tier (not color-only)", () => {
+    const verified = render({ pct: 95, lines: 6 });
+    expect(verified).toContain("aria-label");
+    expect(verified).toContain("verified");
+
+    const partial = render({ pct: 80 });
+    expect(partial).toContain("partial");
+
+    const low = render({ pct: 50 });
+    expect(low).toContain("low");
+  });
+
+  it("includes lines count when provided", () => {
+    const html = render({ pct: 100, lines: 5 });
+    expect(html).toContain("5 lines");
+  });
+
+  it("omits the lines suffix when undefined", () => {
+    const html = render({ pct: 100 });
+    expect(html).not.toContain("lines");
+  });
+});

--- a/tests/lib/audit-middleware.test.ts
+++ b/tests/lib/audit-middleware.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { runAudit } from "@/lib/interview/audit-middleware";
+import type { Guide } from "@/lib/guides/schema";
+
+const guide: Guide = {
+  id: "test-guide",
+  name: "The Tester",
+  sensibility: "x",
+  best_for: ["x"],
+  voice_rules: ["x"],
+  allowed: ["x"],
+  forbidden: ["draft any line of the artifact"],
+  question_bank: ["x?"],
+  audit_flags: [
+    {
+      name: "drafted_line",
+      description: "The message contains a draftable line.",
+    },
+  ],
+  sample_meta_comments: [],
+  description: "",
+  source: "builtin",
+};
+
+interface MockClient {
+  messages: {
+    create: ReturnType<typeof vi.fn>;
+  };
+}
+
+function makeClient(impl: (...args: unknown[]) => unknown): MockClient {
+  return { messages: { create: vi.fn().mockImplementation(impl) } };
+}
+
+const auditResponse = (flags: string[], reason: string) => ({
+  content: [
+    {
+      type: "tool_use",
+      name: "record_audit",
+      input: { flags_tripped: flags, reason },
+    },
+  ],
+});
+
+beforeEach(() => {
+  delete process.env.AUDIT_BLOCK;
+});
+afterEach(() => {
+  delete process.env.AUDIT_BLOCK;
+});
+
+describe("runAudit", () => {
+  it("returns allow=true and empty flags on a clean message", async () => {
+    const client = makeClient(async () => auditResponse([], ""));
+    const result = await runAudit({
+      message: "clean question?",
+      guide,
+      client: client as never,
+    });
+    expect(result.allow).toBe(true);
+    expect(result.flags_tripped).toEqual([]);
+  });
+
+  it("default (log-only) mode: flags tripped but allow stays true", async () => {
+    const client = makeClient(async () =>
+      auditResponse(["drafted_line"], "draft detected"),
+    );
+    const result = await runAudit({
+      message: "Tomas kept a notebook in his coat pocket.",
+      guide,
+      client: client as never,
+    });
+    expect(result.allow).toBe(true);
+    expect(result.flags_tripped).toEqual(["drafted_line"]);
+    expect(result.reason).toBe("draft detected");
+  });
+
+  it("AUDIT_BLOCK=1: flags tripped → allow=false", async () => {
+    process.env.AUDIT_BLOCK = "1";
+    const client = makeClient(async () =>
+      auditResponse(["drafted_line"], "draft detected"),
+    );
+    const result = await runAudit({
+      message: "drafty content",
+      guide,
+      client: client as never,
+    });
+    expect(result.allow).toBe(false);
+    expect(result.flags_tripped).toEqual(["drafted_line"]);
+  });
+
+  it("AUDIT_BLOCK=1 but no flags tripped → allow=true", async () => {
+    process.env.AUDIT_BLOCK = "1";
+    const client = makeClient(async () => auditResponse([], ""));
+    const result = await runAudit({
+      message: "clean",
+      guide,
+      client: client as never,
+    });
+    expect(result.allow).toBe(true);
+  });
+
+  it("on Anthropic failure, allow=true (don't block on infra)", async () => {
+    const client = makeClient(async () => {
+      throw new Error("model unavailable");
+    });
+    const result = await runAudit({
+      message: "anything",
+      guide,
+      client: client as never,
+    });
+    expect(result.allow).toBe(true);
+    expect(result.flags_tripped).toEqual([]);
+    expect(result.reason).toBe("");
+  });
+});

--- a/tests/lib/provenance-match.test.ts
+++ b/tests/lib/provenance-match.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import { matchProvenance } from "@/lib/provenance/match";
+import type { Turn } from "@/lib/types/session";
+
+const userTurn = (id: string, text: string): Turn => ({
+  id,
+  session_id: "s",
+  role: "user",
+  text,
+  ts: 1,
+});
+
+describe("matchProvenance", () => {
+  it("matches an exact substring as 'exact' and tags the source turn", () => {
+    const turns = [
+      userTurn("u1", "Her hands always smelled like garlic and orange peel."),
+    ];
+    const result = matchProvenance("Her hands", turns);
+    expect(result.provenance[0]!.match).toBe("exact");
+    expect(result.provenance[0]!.source_turn_id).toBe("u1");
+    expect(result.provenance[0]!.source_text).toContain("garlic");
+  });
+
+  it("byline_pct is 100 when every line exact-matches", () => {
+    const turns = [
+      userTurn(
+        "u1",
+        "Her hands smelled like garlic. The kitchen was small.",
+      ),
+    ];
+    const artifact = "Her hands smelled like garlic\nThe kitchen was small";
+    const result = matchProvenance(artifact, turns);
+    expect(result.byline_pct).toBe(100);
+    expect(result.provenance.every((p) => p.match === "exact")).toBe(true);
+  });
+
+  it("matches a typoed line within 2 edits per word as 'fuzzy'", () => {
+    const turns = [userTurn("u1", "Her hands smelled like garlic")];
+    // hnads / smeld are within ≤2 edits of hands / smelled.
+    const result = matchProvenance("Her hnads smeld like garlic", turns);
+    expect(result.provenance[0]!.match).toBe("fuzzy");
+  });
+
+  it("returns 'none' for paraphrased lines (more than 2 edits per word)", () => {
+    const turns = [userTurn("u1", "Her hands smelled like garlic")];
+    const result = matchProvenance("Her arms reeked of pepper", turns);
+    expect(result.provenance[0]!.match).toBe("none");
+  });
+
+  it("preserves blank lines as 'none' without affecting byline_pct", () => {
+    const turns = [userTurn("u1", "Hello world")];
+    const result = matchProvenance("Hello world\n\nHello world", turns);
+    expect(result.provenance).toHaveLength(3);
+    expect(result.provenance[0]!.match).toBe("exact");
+    expect(result.provenance[1]!.match).toBe("none");
+    expect(result.provenance[1]!.line).toBe("");
+    expect(result.provenance[2]!.match).toBe("exact");
+    // 4 verified words / 4 total → 100
+    expect(result.byline_pct).toBe(100);
+  });
+
+  it("returns byline_pct 0 on empty input", () => {
+    const result = matchProvenance("", []);
+    expect(result.byline_pct).toBe(0);
+    expect(result.provenance[0]!.match).toBe("none");
+  });
+
+  it("ignores guide turns when matching", () => {
+    const turns: Turn[] = [
+      {
+        id: "g1",
+        session_id: "s",
+        role: "guide",
+        text: "What did she say?",
+        ts: 1,
+      },
+      userTurn("u1", "She said pronto"),
+    ];
+    // The guide's text is an exact substring of the artifact, but guides aren't sources.
+    const result = matchProvenance("What did she say?", turns);
+    expect(result.provenance[0]!.match).toBe("none");
+  });
+
+  it("computes byline_pct correctly for mixed exact/none lines", () => {
+    const turns = [userTurn("u1", "First line of user content")];
+    const artifact = "First line\nUnrelated paraphrased prose here entirely";
+    const result = matchProvenance(artifact, turns);
+    expect(result.provenance[0]!.match).toBe("exact");
+    expect(result.provenance[1]!.match).toBe("none");
+    // 2 verified words ("First line") + 6 unverified ("Unrelated paraphrased prose here entirely") = 8 total.
+    // wait, "Unrelated paraphrased prose here entirely" is 5 words. Recompute.
+    // verified=2, total=2+5=7, pct=2/7≈29
+    expect(result.byline_pct).toBeGreaterThan(20);
+    expect(result.byline_pct).toBeLessThan(40);
+  });
+
+  it("preserves the original line whitespace in the output", () => {
+    const turns = [userTurn("u1", "indented content")];
+    const result = matchProvenance("  indented content  ", turns);
+    expect(result.provenance[0]!.line).toBe("  indented content  ");
+    expect(result.provenance[0]!.match).toBe("exact");
+  });
+
+  it("is empty turns => everything is 'none'", () => {
+    const result = matchProvenance("Some artifact text\nAnother line", []);
+    expect(result.provenance.every((p) => p.match === "none")).toBe(true);
+    expect(result.byline_pct).toBe(0);
+  });
+});

--- a/tests/lib/store.test.ts
+++ b/tests/lib/store.test.ts
@@ -82,6 +82,15 @@ describe("reducer", () => {
     expect(next.turns).toEqual(INITIAL_STATE.turns);
   });
 
+  it("set_artifact_text replaces the artifact_text", () => {
+    const next = reducer(
+      INITIAL_STATE,
+      actions.setArtifactText("Tomas kept a notebook."),
+    );
+    expect(next.artifact_text).toBe("Tomas kept a notebook.");
+    expect(INITIAL_STATE.artifact_text).toBe("");
+  });
+
   it("append_turn pushes turns immutably", () => {
     const turn1: Turn = {
       id: "g1",


### PR DESCRIPTION
## Sprint 3 of #26 — provenance + audit + critique + Drafting/Render

Single-handed (Pruthvi cut). All Sprint-3 acceptance items in #26 hit. Five phase commits — each independently green; final state has 177 / 177 tests passing.

### What landed

**New routes (deterministic + LLM)**

| Route | Behavior |
|---|---|
| `POST /api/provenance` | Node runtime, no key required. Pure call into `lib/provenance/match`. Input `{ artifact, turns }` → `{ provenance, byline_pct }`. |
| `POST /api/audit` | Haiku 4.5 with structured tool output (`record_audit`). Stub fallback when no key. Same shape contract as the middleware. |

**Rewritten route (stub fallback preserved)**

| Route | Behavior |
|---|---|
| `POST /api/draft/critique` | Sonnet 4.6 critic mode. SSE: one `event: card` per `record_critique_card` tool call (cliche / question / verified), then `event: done`. Stub mode unchanged — still returns `{ stub: true, cards }` JSON. Cache_control: ephemeral on system block. |

**New libs**

- `lib/provenance/match.ts` — pure deterministic matcher. Per artifact line: exact substring against user turns; if miss, per-word Levenshtein with ≤2 edit distance and a sliding window over the turn; otherwise `'none'`. Only `role: 'user'` turns count as sources. `byline_pct` = verified_words / total_words.
- `lib/interview/audit-middleware.ts` — `runAudit(message, guide, client)` calls Haiku 4.5 with the active guide's `audit_flags`. Default mode is log-only (`allow=true` even when flags fire); `process.env.AUDIT_BLOCK==="1"` promotes to blocking. Infra failures yield `allow=true` so an outage doesn't DoS the interview.

**Modified route**

- `app/api/interview/turn/route.ts` — wires `runAudit` after `finalMessage`. Flagged turns log warn; blocked turns emit an `audit_blocked` SSE frame and close the stream. Existing real-mode tests still pass — when the test mock leaves `messages.create` unimplemented, runAudit's catch-all returns `allow=true`.

**Components**

- `components/BylineMeter.tsx` — color band PLUS iconography (✓/◐/⚠) so it's not color-only. `aria-label` discloses the tier verbatim. Clamps pct to `[0, 100]`, rounds non-integers.
- `components/screens/Drafting.tsx` — split-A layout (left: textarea editor; right: streaming critique pane). Debounced fetch on user pause (600ms). Previous in-flight critique is aborted on each keystroke. Handles both stub-mode JSON and real-mode SSE responses. Persists draft to `state.artifact_text` so Render can read it.
- `components/screens/Render.tsx` — upgraded to fetch `/api/provenance` on mount when `artifact_text` + `turns` are present. Real provenance replaces the SCRIPT-driven `src → Q+A` mapping; the hover popover walks `turns[]` back one step from the source turn to find the original guide question. Falls back to the eulogy SCRIPT when no real artifact exists. Lines are keyboard-reachable via `tabIndex` with focus-driven hover. Postmark percentage now reflects live `byline_pct`. `BylineMeter` rendered alongside the wax seal.

**Store**

- `lib/store.ts` — adds `AppState.artifact_text` + `setArtifactText` action. PersistedSchema extended with `default("")` so existing v1 localStorage upgrades cleanly. Drafting writes; Render reads.

**App wiring**

- `components/App.tsx` — `step === "drafting"` now routes to `Drafting`.

### Tests — 65 new across this PR

| Suite | Cases |
|---|---|
| `tests/lib/provenance-match.test.ts` | 10 — exact / fuzzy / none / blank lines / empty / mixed pct / guide-turn exclusion / whitespace preservation |
| `tests/api/provenance.test.ts` | 5 — happy path / malformed body / non-JSON / empty turns / optional Turn fields |
| `tests/lib/audit-middleware.test.ts` | 5 — clean / log-only flagged / `AUDIT_BLOCK=1` flagged blocks / `AUDIT_BLOCK=1` clean still allows / infra failure → allow=true |
| `tests/api/audit.test.ts` | 6 — stub mode / clean / flagged / 404 / 400 malformed / 400 non-JSON |
| `tests/api/draft-critique-real.test.ts` | 5 — three-card streaming / invalid tool input dropped / no tool calls still emits done / 404 / SDK error → error frame |
| `tests/components/BylineMeter.test.ts` | 8 — each tier / clamping / rounding / aria-label tier disclosure / lines count / no-lines mode |
| `tests/lib/store.test.ts` | +1 — `setArtifactText` |
| `tests/api/draft-critique.test.ts` | hardened — file-scoped SDK mock prevents the BYO-key-leak test from making real Anthropic calls now that BYO triggers real-mode |

### Acceptance items (#26 § Sprint 3)

- [x] `lib/provenance/match.ts` — exact + Levenshtein fallback (≤2 edit distance per word). Pure.
- [x] `POST /api/provenance` — Node runtime, deterministic.
- [x] `POST /api/audit` — Haiku 4.5 flag-driven.
- [x] `lib/interview/audit-middleware.ts` — log-only by default, `AUDIT_BLOCK=1` promotes to blocking.
- [x] Wraps `/api/interview/turn`.
- [x] `POST /api/draft/critique` rewritten — Sonnet 4.6, 3 buckets, streaming, stub fallback.
- [x] `components/screens/Drafting.tsx` — split editor + streaming critique.
- [x] `components/screens/Render.tsx` upgraded — consumes real `provenance[]`.
- [x] `components/BylineMeter.tsx` — green / yellow / red + iconography (NOT color-only); WCAG AA focus indicators.
- [x] Tests: matcher coverage, audit middleware log-vs-block, critique stub→real swap.

### Notes
- Critique's "card-by-card" streaming is implemented via `finalMessage` rather than per-`contentBlock` events — cards are emitted in a single burst at end of stream rather than as Sonnet generates each tool call. The UX difference is small (~1-2s) and the test surface is much simpler. If we want true per-card streaming, switch to `ms.on('contentBlock', ...)` later.
- `AUDIT_BLOCK` blocking happens AFTER deltas have already streamed (audit runs on `finalMessage`). The route emits `audit_blocked` so the frontend can dim/warn; it can't unstream the text. Documented limitation.

### Gates

```
tsc --noEmit               ✓
vitest run                 177 / 177 across 22 files
next lint                  ✓
next build                 ✓ (production build, all routes resolved)
```

Refs #26 (Sprint 3 of three; Sprint 4 lands on `feat/sprint-4-guide-share` per the PR strategy in the issue body).