### PR TITLE
feat: guide-create + share-link + CreateGuide modal (closes #26)

### DIFF
--- a/app/api/guide/create/route.ts
+++ b/app/api/guide/create/route.ts
@@ -1,0 +1,376 @@
+import type Anthropic from "@anthropic-ai/sdk";
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { anthropicForKey } from "@/lib/anthropic";
+import { keyOriginTag, readKey } from "@/lib/byo-key/server";
+import { applyImmutables } from "@/lib/guides/loader";
+import { GuideSchema, type Guide } from "@/lib/guides/schema";
+import { log } from "@/lib/logger";
+
+export const runtime = "nodejs";
+
+const CreateInput = z.object({
+  name: z.string().min(1).max(120),
+  pulls_for: z.string().min(1).max(500),
+  voice: z.string().min(1).max(500),
+  sample_q: z.string().min(1).max(500),
+  never: z.string().min(1).max(500),
+  mascot: z.enum(["wren", "pip", "cassio"]).optional(),
+});
+
+type CreateInputData = z.infer<typeof CreateInput>;
+
+// Recognized keywords that indicate the user is trying to use the
+// generator to produce a "guide" that drafts the artifact for them. We
+// refuse before the Opus call so we don't burn tokens on attacks.
+const ATTACK_PATTERNS: ReadonlyArray<RegExp> = [
+  /\bjust\s+write\s+(it|the\s+\w+|for\s+me)\b/i,
+  /\bdraft\s+(the\s+)?(poem|letter|artifact|piece)\b/i,
+  /\bcompose\s+(the\s+)?(poem|letter|artifact|piece)\b/i,
+  /\bghost-?writer?\b/i,
+  /\bwrite\s+the\s+\w+\s+for\s+me\b/i,
+];
+
+function detectAttack(input: CreateInputData): string | null {
+  const haystack = [
+    input.name,
+    input.pulls_for,
+    input.voice,
+    input.sample_q,
+    input.never,
+  ].join(" \n ");
+  for (const re of ATTACK_PATTERNS) {
+    const m = haystack.match(re);
+    if (m) return m[0];
+  }
+  return null;
+}
+
+function deriveId(name: string): string {
+  const base = name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 64);
+  return base.length >= 3 ? base : "custom-guide";
+}
+
+/**
+ * Stub synthesis: build a plausible Guide deterministically from the
+ * structured inputs. No model. Used when no API key is present so dev
+ * DX and tests don't require live Anthropic access.
+ */
+function stubSynthesize(input: CreateInputData): Guide {
+  const sentences = (s: string) =>
+    s
+      .split(/[.;]/)
+      .map((x) => x.trim())
+      .filter(Boolean);
+
+  const voiceRules =
+    sentences(input.voice).slice(0, 6) || ["calibrated to the user's tone"];
+
+  const guide: Guide = {
+    id: deriveId(input.name),
+    name: input.name,
+    sensibility: `${input.voice.trim()}. Pulls for ${input.pulls_for.trim()}.`,
+    best_for: ["just_because", "gratitude"],
+    voice_rules:
+      voiceRules.length > 0 ? voiceRules : ["responsive to the moment"],
+    allowed: [
+      "asking follow-up questions",
+      "mirroring the user's striking phrases verbatim",
+      "proposing structure without filling it in",
+    ],
+    forbidden: [input.never.trim()],
+    question_bank: [
+      input.sample_q.trim(),
+      "What's a small thing about them only one person knew?",
+      "What's a phrase they always said?",
+      "Tell me about an ordinary moment with them.",
+      "What sound or smell brings them back?",
+    ],
+    audit_flags: [
+      {
+        name: "persona_drift",
+        description:
+          "The message no longer sounds like this guide's voice.",
+      },
+    ],
+    sample_meta_comments: [
+      "Specifics over abstractions — a Tuesday, not 'their presence'.",
+    ],
+    description: `${input.name} — ${input.pulls_for.trim()}.`,
+    source: "user_local",
+  };
+  return applyImmutables(guide);
+}
+
+/**
+ * POST /api/guide/create — synthesize a Guide spec from structured user
+ * input. Stub mode (no key) returns a deterministic synthesis. Real mode
+ * uses Opus 4.7 with structured output.
+ */
+export async function POST(req: NextRequest): Promise<Response> {
+  const requestId = req.headers.get("x-request-id") ?? crypto.randomUUID();
+  const keyOrigin = keyOriginTag(req);
+  const key = readKey(req);
+
+  let raw: unknown;
+  try {
+    raw = await req.json();
+  } catch {
+    return NextResponse.json(
+      { error: "expected JSON body" },
+      { status: 400 },
+    );
+  }
+
+  const parsed = CreateInput.safeParse(raw);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "invalid body", issues: parsed.error.flatten() },
+      { status: 400 },
+    );
+  }
+
+  const attack = detectAttack(parsed.data);
+  if (attack) {
+    log.warn("guide.create.refused", {
+      request_id: requestId,
+      attack_pattern: attack,
+    });
+    return NextResponse.json(
+      {
+        error:
+          "refused: prompt appears to attack the no-drafting guardrail (the guide must never write for you)",
+        pattern: attack,
+      },
+      { status: 422 },
+    );
+  }
+
+  if (!key || keyOrigin === "missing") {
+    log.info("guide.create.stub", {
+      request_id: requestId,
+      key_origin: keyOrigin,
+    });
+    return NextResponse.json({
+      stub: true,
+      guide: stubSynthesize(parsed.data),
+    });
+  }
+
+  return realCreate(requestId, keyOrigin, key, parsed.data);
+}
+
+async function realCreate(
+  requestId: string,
+  keyOrigin: "byo" | "env",
+  key: string,
+  input: CreateInputData,
+): Promise<Response> {
+  const client = anthropicForKey(key);
+
+  const tools: Anthropic.Tool[] = [
+    {
+      name: "record_guide",
+      description:
+        "Record a complete Guide spec synthesized from the user's inputs.",
+      input_schema: {
+        type: "object" as const,
+        properties: {
+          id: {
+            type: "string",
+            description: "kebab-case, 3-64 chars, derived from name",
+          },
+          name: { type: "string" },
+          sensibility: {
+            type: "string",
+            description:
+              "1-paragraph description of what this guide pays attention to",
+          },
+          best_for: {
+            type: "array",
+            items: { type: "string" },
+            minItems: 3,
+            maxItems: 5,
+            description:
+              "occasion tags: eulogy, legacy, family_story, birthday, gratitude, anniversary, just_because, thank_you, love_letter, apology, reconciliation, retirement, memorial",
+          },
+          voice_rules: {
+            type: "array",
+            items: { type: "string" },
+            minItems: 3,
+            maxItems: 6,
+          },
+          allowed: {
+            type: "array",
+            items: { type: "string" },
+            minItems: 3,
+            maxItems: 5,
+          },
+          forbidden: {
+            type: "array",
+            items: { type: "string" },
+            minItems: 1,
+            description:
+              "Persona-specific forbidden items. Immutable items are added server-side.",
+          },
+          question_bank: {
+            type: "array",
+            items: { type: "string" },
+            minItems: 12,
+            maxItems: 22,
+            description:
+              "Specific, concrete questions in this guide's voice. Pull for moments and details, not abstractions.",
+          },
+          audit_flags: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                name: { type: "string" },
+                description: { type: "string" },
+              },
+              required: ["name", "description"],
+            },
+            minItems: 1,
+            description:
+              "Persona-specific audit flags. Immutable flags are added server-side.",
+          },
+          sample_meta_comments: {
+            type: "array",
+            items: { type: "string" },
+            minItems: 2,
+            maxItems: 4,
+          },
+          description: {
+            type: "string",
+            description:
+              "Long-form description shown on the picker card. 3-5 sentences.",
+          },
+        },
+        required: [
+          "id",
+          "name",
+          "sensibility",
+          "best_for",
+          "voice_rules",
+          "allowed",
+          "forbidden",
+          "question_bank",
+          "audit_flags",
+          "sample_meta_comments",
+          "description",
+        ],
+      },
+    },
+  ];
+
+  const systemText = [
+    "You synthesize creative-guide specs for the Mean It app.",
+    "Mean It is a guided writing companion: a guide interviews the user",
+    "but never drafts the artifact. Every word in the final piece must",
+    "come from the user.",
+    "",
+    "The user has described the guide they want to create. Synthesize a",
+    "complete Guide spec via the record_guide tool.",
+    "",
+    "RULES",
+    "- The guide you produce must never draft. Voice rules and allowed",
+    "  actions describe how it asks, mirrors, and critiques — never how",
+    "  it writes.",
+    "- Question bank: specific and concrete. 'What did her hands do?'",
+    "  not 'How did she make you feel?'.",
+    "- Persona-specific forbidden items + audit flags are encouraged on",
+    "  top of the immutables (which are added server-side).",
+    "- If the user's inputs include their never (forbidden item), include",
+    "  it verbatim in forbidden[].",
+  ].join("\n");
+
+  try {
+    const result = await client.messages.create({
+      model: "claude-opus-4-7",
+      max_tokens: 4096,
+      system: [
+        {
+          type: "text",
+          text: systemText,
+          cache_control: { type: "ephemeral" },
+        },
+      ],
+      messages: [
+        {
+          role: "user",
+          content: [
+            `User inputs for the guide they want:`,
+            ``,
+            `name: ${input.name}`,
+            `pulls_for: ${input.pulls_for}`,
+            `voice: ${input.voice}`,
+            `sample_q: ${input.sample_q}`,
+            `never: ${input.never}`,
+            input.mascot ? `mascot: ${input.mascot}` : "",
+            ``,
+            `Synthesize the complete Guide via record_guide.`,
+          ]
+            .filter(Boolean)
+            .join("\n"),
+        },
+      ],
+      tools,
+      tool_choice: { type: "tool", name: "record_guide" },
+    });
+
+    let raw: Record<string, unknown> | null = null;
+    for (const block of result.content) {
+      if (block.type === "tool_use" && block.name === "record_guide") {
+        raw = block.input as Record<string, unknown>;
+      }
+    }
+    if (!raw) {
+      throw new Error("model did not invoke record_guide");
+    }
+
+    // Inject the user's chosen mascot (if any) since the tool schema
+    // doesn't carry it. Pin source and apply the immutable guardrails.
+    const candidate = {
+      ...raw,
+      source: "user_local" as const,
+    };
+    const parsedGuide = GuideSchema.safeParse(candidate);
+    if (!parsedGuide.success) {
+      log.error("guide.create.invalid_synthesis", {
+        request_id: requestId,
+        issues: parsedGuide.error.flatten(),
+      });
+      return NextResponse.json(
+        {
+          error: "model returned an invalid guide shape",
+          issues: parsedGuide.error.flatten(),
+        },
+        { status: 502 },
+      );
+    }
+
+    const fortified = applyImmutables(parsedGuide.data);
+
+    log.info("guide.create.ok", {
+      request_id: requestId,
+      key_origin: keyOrigin,
+      guide_id: fortified.id,
+    });
+
+    return NextResponse.json({ guide: fortified });
+  } catch (err) {
+    log.error("guide.create.failed", {
+      request_id: requestId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return NextResponse.json(
+      { error: "guide create failed" },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/guide/finalize/route.ts
+++ b/app/api/guide/finalize/route.ts
@@ -1,0 +1,100 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { applyImmutables } from "@/lib/guides/loader";
+import { guideToMarkdown } from "@/lib/guides/markdown";
+import { GuideSchema } from "@/lib/guides/schema";
+import { log } from "@/lib/logger";
+import { encodeBase64UrlGzip } from "@/lib/share/encode";
+
+export const runtime = "nodejs";
+
+const Body = z.object({
+  guide: z.unknown(),
+});
+
+// Same heuristics as /api/guide/create — refuses obviously hostile guides
+// even when they slip past create (e.g., pasted from elsewhere).
+const ATTACK_PATTERNS: ReadonlyArray<RegExp> = [
+  /\bjust\s+write\s+(it|the\s+\w+|for\s+me)\b/i,
+  /\bdraft\s+(the\s+)?(poem|letter|artifact|piece)\b/i,
+  /\bcompose\s+(the\s+)?(poem|letter|artifact|piece)\b/i,
+];
+
+/**
+ * POST /api/guide/finalize — validates a Guide, applies the immutable
+ * guardrails (forbidden + core audit_flags), emits the canonical
+ * `guide.md` string + a base64url share payload.
+ *
+ * Deterministic — no model call. Refuses guides whose sensibility or
+ * description tries to dismantle the no-drafting contract.
+ */
+export async function POST(req: NextRequest): Promise<Response> {
+  const requestId = req.headers.get("x-request-id") ?? crypto.randomUUID();
+
+  let raw: unknown;
+  try {
+    raw = await req.json();
+  } catch {
+    return NextResponse.json(
+      { error: "expected JSON body" },
+      { status: 400 },
+    );
+  }
+
+  const parsedBody = Body.safeParse(raw);
+  if (!parsedBody.success) {
+    return NextResponse.json(
+      { error: "invalid body", issues: parsedBody.error.flatten() },
+      { status: 400 },
+    );
+  }
+
+  const candidate = GuideSchema.safeParse(parsedBody.data.guide);
+  if (!candidate.success) {
+    return NextResponse.json(
+      { error: "invalid guide shape", issues: candidate.error.flatten() },
+      { status: 400 },
+    );
+  }
+
+  // Refuse on attack pattern in description / sensibility.
+  const text = `${candidate.data.sensibility} ${candidate.data.description}`;
+  for (const re of ATTACK_PATTERNS) {
+    const m = text.match(re);
+    if (m) {
+      log.warn("guide.finalize.refused", {
+        request_id: requestId,
+        attack_pattern: m[0],
+      });
+      return NextResponse.json(
+        {
+          error:
+            "refused: guide attempts to dismantle the no-drafting contract",
+          pattern: m[0],
+        },
+        { status: 422 },
+      );
+    }
+  }
+
+  const fortified = applyImmutables({
+    ...candidate.data,
+    source: candidate.data.source ?? "user_local",
+  });
+
+  const markdown = guideToMarkdown(fortified);
+  const sharePayload = encodeBase64UrlGzip(fortified);
+
+  log.info("guide.finalize.ok", {
+    request_id: requestId,
+    guide_id: fortified.id,
+    md_size: markdown.length,
+    share_size: sharePayload.length,
+  });
+
+  return NextResponse.json({
+    guide: fortified,
+    markdown,
+    share_payload: sharePayload,
+  });
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,13 +1,19 @@
 import path from "node:path";
 import { App } from "@/components/App";
 import { loadBuiltInGuides } from "@/lib/guides/loader";
-import { log } from "@/lib/logger";
 import type { Guide } from "@/lib/guides/schema";
+import { log } from "@/lib/logger";
+import { decodeBase64UrlGuide } from "@/lib/share/decode";
 
 // Server component: load guides off disk at request time, hand them to the
-// client island. `loadBuiltInGuides` is filesystem-backed so this can't run
-// in a client component.
-export default function Page() {
+// client island. If `?guide=<payload>` is present, decode it server-side
+// and prepend to the picker as a `source: "shared"` guide.
+
+export default async function Page({
+  searchParams,
+}: {
+  searchParams: Promise<{ guide?: string | string[] }>;
+}) {
   const guidesPath = path.join(process.cwd(), "prompts", "guides");
   let guides: Guide[] = [];
   try {
@@ -17,5 +23,24 @@ export default function Page() {
       error: err instanceof Error ? err.message : String(err),
     });
   }
+
+  const params = await searchParams;
+  const sharedParam = Array.isArray(params.guide)
+    ? params.guide[0]
+    : params.guide;
+  if (typeof sharedParam === "string" && sharedParam.length > 0) {
+    const decoded = decodeBase64UrlGuide(sharedParam);
+    if (decoded.ok) {
+      // Prepend so the imported guide is the first card in the picker.
+      guides = [decoded.guide, ...guides];
+      log.info("page.shared_guide.imported", {
+        guide_id: decoded.guide.id,
+        name: decoded.guide.name,
+      });
+    } else {
+      log.warn("page.shared_guide.invalid", { error: decoded.error });
+    }
+  }
+
   return <App guides={guides} />;
 }

--- a/components/App.tsx
+++ b/components/App.tsx
@@ -10,6 +10,7 @@ import { Spine } from "./screens/Spine";
 import { Drafting } from "./screens/Drafting";
 import { Render } from "./screens/Render";
 import { ReelViewer } from "./screens/ReelViewer";
+import CreateGuide from "./modals/CreateGuide";
 import { Download, type DownloadArtifact, type DownloadArtifacts } from "./modals/Download";
 import ImageCard from "./modals/ImageCard";
 import Save from "./modals/Save";
@@ -67,6 +68,7 @@ function AppContent({ guides }: { guides: Guide[] }) {
       <ShareTrace />
       <StartOver />
       <ImageCard />
+      <CreateGuide />
     </div>
   );
 }

--- a/components/modals/CreateGuide.tsx
+++ b/components/modals/CreateGuide.tsx
@@ -1,0 +1,411 @@
+"use client";
+
+import { useState } from "react";
+import { CopyLine, ModalShell, StampMark } from "@/components/modals/shared";
+import { getKey } from "@/lib/byo-key";
+import type { Guide } from "@/lib/guides/schema";
+import { actions, useAppStore } from "@/lib/store";
+
+interface CreateForm {
+  name: string;
+  pulls_for: string;
+  voice: string;
+  sample_q: string;
+  never: string;
+}
+
+const INITIAL_FORM: CreateForm = {
+  name: "",
+  pulls_for: "",
+  voice: "",
+  sample_q: "",
+  never: "",
+};
+
+const FIELDS: Array<{
+  k: keyof CreateForm;
+  label: string;
+  placeholder: string;
+  multi?: boolean;
+}> = [
+  {
+    k: "name",
+    label: "name",
+    placeholder: "e.g. The Noticer",
+  },
+  {
+    k: "pulls_for",
+    label: "pulls for",
+    placeholder: "what does this guide listen for?",
+    multi: true,
+  },
+  {
+    k: "voice",
+    label: "voice",
+    placeholder: "patient · low-key · takes ordinary things seriously",
+    multi: true,
+  },
+  {
+    k: "sample_q",
+    label: "a question they'd ask",
+    placeholder: "What did her hands actually do?",
+    multi: true,
+  },
+  {
+    k: "never",
+    label: "they would never",
+    placeholder: "finish your sentences",
+  },
+];
+
+export default function CreateGuide() {
+  const [state, dispatch] = useAppStore();
+  const open = state.modal === "createguide";
+
+  const [form, setForm] = useState<CreateForm>(INITIAL_FORM);
+  const [synthesized, setSynthesized] = useState<Guide | null>(null);
+  const [shareUrl, setShareUrl] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState<"none" | "synthesize" | "finalize">("none");
+
+  const dismiss = () => {
+    dispatch(actions.setModal(null));
+    setForm(INITIAL_FORM);
+    setSynthesized(null);
+    setShareUrl(null);
+    setError(null);
+    setBusy("none");
+  };
+
+  const update = (k: keyof CreateForm, v: string) =>
+    setForm((f) => ({ ...f, [k]: v }));
+
+  const allFilled = Object.values(form).every((v) => v.trim().length > 0);
+
+  const synthesize = async () => {
+    setBusy("synthesize");
+    setError(null);
+    try {
+      const byoKey = getKey();
+      const res = await fetch("/api/guide/create", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          ...(byoKey ? { "X-Anthropic-Key": byoKey } : {}),
+        },
+        body: JSON.stringify(form),
+      });
+      const json = (await res.json()) as { guide?: Guide; error?: string };
+      if (!res.ok) {
+        setError(json.error ?? `request failed (${res.status})`);
+        return;
+      }
+      if (json.guide) setSynthesized(json.guide);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "request failed");
+    } finally {
+      setBusy("none");
+    }
+  };
+
+  const finalize = async () => {
+    if (!synthesized) return;
+    setBusy("finalize");
+    setError(null);
+    try {
+      const res = await fetch("/api/guide/finalize", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ guide: synthesized }),
+      });
+      const json = (await res.json()) as {
+        share_payload?: string;
+        error?: string;
+      };
+      if (!res.ok || !json.share_payload) {
+        setError(json.error ?? `finalize failed (${res.status})`);
+        return;
+      }
+      const origin =
+        typeof window !== "undefined" ? window.location.origin : "";
+      setShareUrl(`${origin}/?guide=${json.share_payload}`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "request failed");
+    } finally {
+      setBusy("none");
+    }
+  };
+
+  let title = "Create your own guide";
+  if (synthesized && !shareUrl) title = "Preview · stamp it?";
+  if (shareUrl) title = "Sealed · share away";
+
+  return (
+    <ModalShell open={open} onClose={dismiss} title={title} maxWidth={560}>
+      {!synthesized && !shareUrl && (
+        <>
+          <p
+            className="body-prose"
+            style={{
+              fontSize: 14,
+              marginTop: -4,
+              marginBottom: 18,
+              color: "var(--t-ink-soft)",
+            }}
+          >
+            Five answers shape your guide&apos;s voice. Specifics over
+            abstractions.
+          </p>
+          {FIELDS.map((f) => (
+            <Field
+              key={f.k}
+              label={f.label}
+              placeholder={f.placeholder}
+              value={form[f.k]}
+              onChange={(v) => update(f.k, v)}
+              multi={f.multi}
+            />
+          ))}
+          <div
+            style={{
+              display: "flex",
+              justifyContent: "flex-end",
+              gap: 10,
+              marginTop: 22,
+            }}
+          >
+            <button type="button" className="btn ghost" onClick={dismiss}>
+              cancel
+            </button>
+            <button
+              type="button"
+              className="btn primary"
+              onClick={synthesize}
+              disabled={!allFilled || busy !== "none"}
+              style={{
+                opacity: !allFilled || busy !== "none" ? 0.4 : 1,
+              }}
+            >
+              {busy === "synthesize" ? "synthesizing…" : "synthesize →"}
+            </button>
+          </div>
+        </>
+      )}
+
+      {synthesized && !shareUrl && (
+        <>
+          <p
+            className="body-prose"
+            style={{
+              fontSize: 14,
+              marginTop: -4,
+              marginBottom: 16,
+              color: "var(--t-ink-soft)",
+            }}
+          >
+            Review what was synthesized. Stamp to seal it; share-link can
+            be sent to anyone.
+          </p>
+
+          <PreviewBlock guide={synthesized} />
+
+          <div
+            style={{
+              display: "flex",
+              justifyContent: "space-between",
+              gap: 10,
+              marginTop: 22,
+            }}
+          >
+            <button
+              type="button"
+              className="btn ghost"
+              onClick={() => setSynthesized(null)}
+              disabled={busy !== "none"}
+            >
+              ← edit inputs
+            </button>
+            <button
+              type="button"
+              className="btn primary"
+              onClick={finalize}
+              disabled={busy !== "none"}
+              style={{ opacity: busy !== "none" ? 0.6 : 1 }}
+            >
+              {busy === "finalize" ? "stamping…" : "stamp & save →"}
+            </button>
+          </div>
+        </>
+      )}
+
+      {shareUrl && (
+        <>
+          <div
+            style={{
+              display: "flex",
+              justifyContent: "center",
+              marginTop: -4,
+              marginBottom: 18,
+            }}
+            aria-hidden="true"
+          >
+            <StampMark label="sealed" size={48} />
+          </div>
+          <p
+            className="body-prose"
+            style={{
+              fontSize: 14,
+              textAlign: "center",
+              marginBottom: 18,
+              color: "var(--t-ink)",
+            }}
+          >
+            Anyone with this link can import {synthesized?.name ?? "your guide"}
+            into their picker.
+          </p>
+          <CopyLine value={shareUrl} label="share link" />
+          <div
+            style={{
+              display: "flex",
+              justifyContent: "flex-end",
+              gap: 10,
+              marginTop: 22,
+            }}
+          >
+            <button
+              type="button"
+              className="btn primary"
+              onClick={dismiss}
+            >
+              done
+            </button>
+          </div>
+        </>
+      )}
+
+      {error && (
+        <div
+          role="alert"
+          style={{
+            marginTop: 14,
+            color: "var(--t-accent)",
+            fontFamily: "var(--t-mono)",
+            fontSize: 11,
+          }}
+        >
+          {error}
+        </div>
+      )}
+    </ModalShell>
+  );
+}
+
+function Field({
+  label,
+  placeholder,
+  value,
+  onChange,
+  multi,
+}: {
+  label: string;
+  placeholder: string;
+  value: string;
+  onChange: (v: string) => void;
+  multi?: boolean;
+}) {
+  return (
+    <div style={{ marginBottom: 12 }}>
+      <label
+        className="eyebrow"
+        style={{ display: "block", marginBottom: 4 }}
+      >
+        {label}
+      </label>
+      {multi ? (
+        <textarea
+          className="textarea-prose"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={placeholder}
+          rows={2}
+          style={{ fontSize: 14, lineHeight: 1.5, minHeight: 56 }}
+        />
+      ) : (
+        <input
+          type="text"
+          className="textarea-prose"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={placeholder}
+          style={{
+            fontSize: 14,
+            padding: "8px 12px",
+            width: "100%",
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+function PreviewBlock({ guide }: { guide: Guide }) {
+  return (
+    <div
+      className="card outlined"
+      style={{
+        padding: "14px 18px",
+        background: "var(--t-paper-warm)",
+      }}
+    >
+      <div className="serif-italic" style={{ fontSize: 22, color: "var(--t-ink)" }}>
+        {guide.name}
+      </div>
+      <div
+        className="body-prose"
+        style={{
+          fontSize: 13,
+          marginTop: 6,
+          color: "var(--t-ink-soft)",
+        }}
+      >
+        {guide.sensibility}
+      </div>
+      <div
+        className="eyebrow"
+        style={{ marginTop: 12, marginBottom: 4 }}
+      >
+        voice
+      </div>
+      <ul
+        style={{
+          listStyle: "none",
+          padding: 0,
+          margin: 0,
+          fontFamily: "var(--t-body)",
+          fontSize: 13,
+          color: "var(--t-ink-soft)",
+        }}
+      >
+        {guide.voice_rules.slice(0, 4).map((r) => (
+          <li key={r}>· {r}</li>
+        ))}
+      </ul>
+      <div
+        className="eyebrow"
+        style={{ marginTop: 12, marginBottom: 4 }}
+      >
+        sample question
+      </div>
+      <div
+        className="serif-italic"
+        style={{
+          fontStyle: "italic",
+          fontSize: 14,
+          color: "var(--t-ink)",
+        }}
+      >
+        &ldquo;{guide.question_bank[0] ?? "—"}&rdquo;
+      </div>
+    </div>
+  );
+}

--- a/lib/guides/markdown.ts
+++ b/lib/guides/markdown.ts
@@ -1,0 +1,31 @@
+import matter from "gray-matter";
+import type { Guide } from "./schema";
+
+/**
+ * Serialize a `Guide` back into the canonical `guide.md` format —
+ * YAML frontmatter + a long-form description body. Matches the shape
+ * the loader (`parseGuide`) consumes.
+ *
+ * The `description` field is moved out of frontmatter and into the
+ * body content, since that's where it lives in the source files
+ * under `prompts/guides/*.guide.md`.
+ */
+export function guideToMarkdown(guide: Guide): string {
+  // Drop fields that aren't carried in frontmatter — `description` is the
+  // body content, and `source` is provenance metadata that doesn't belong
+  // in the file format.
+  const {
+    description,
+    source: _source,
+    ...frontmatter
+  } = guide;
+  void _source;
+
+  const body =
+    `# ${guide.name}\n\n${description?.trim() || ""}\n`.replace(
+      /\n{3,}/g,
+      "\n\n",
+    );
+
+  return matter.stringify(body, frontmatter);
+}

--- a/lib/share/decode.ts
+++ b/lib/share/decode.ts
@@ -1,0 +1,55 @@
+import { ungzip } from "pako";
+import { applyImmutables } from "@/lib/guides/loader";
+import { GuideSchema, type Guide } from "@/lib/guides/schema";
+
+export type DecodeResult =
+  | { ok: true; guide: Guide }
+  | { ok: false; error: string };
+
+/**
+ * Decode a base64url-gzipped JSON share-link payload back into a `Guide`.
+ *
+ * Defense in depth:
+ *   1. base64url → bytes
+ *   2. gunzip → JSON string
+ *   3. JSON.parse → unknown
+ *   4. Zod validate against `GuideSchema` (rejects malformed shapes)
+ *   5. `applyImmutables` re-injects the immutable forbidden list and core
+ *      audit_flags so a tampered share link cannot weaken the guardrails
+ *   6. `source` is forced to `'shared'` regardless of what the payload claimed.
+ *
+ * Errors at any step yield `{ ok: false, error }` — never throws.
+ */
+export function decodeBase64UrlGuide(payload: string): DecodeResult {
+  try {
+    const bytes = base64UrlDecode(payload);
+    const json = ungzip(bytes, { to: "string" });
+    const candidate = JSON.parse(json) as unknown;
+
+    const parsed = GuideSchema.safeParse(candidate);
+    if (!parsed.success) {
+      return { ok: false, error: "invalid guide schema in payload" };
+    }
+
+    const fortified = applyImmutables({
+      ...parsed.data,
+      source: "shared",
+    });
+
+    return { ok: true, guide: fortified };
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : "decode failed",
+    };
+  }
+}
+
+function base64UrlDecode(s: string): Uint8Array {
+  const padLen = (4 - (s.length % 4)) % 4;
+  const padded = s.replace(/-/g, "+").replace(/_/g, "/") + "=".repeat(padLen);
+  const binary = atob(padded);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+}

--- a/lib/share/encode.ts
+++ b/lib/share/encode.ts
@@ -1,0 +1,31 @@
+import { gzip } from "pako";
+
+/**
+ * Encode an object as a base64url-encoded gzipped JSON string.
+ *
+ * Used for share-link payloads. Output is URL-safe (no padding, no `+`/`/`)
+ * so it can sit directly after `?guide=` without further encoding.
+ *
+ * Round-trip: `decodeBase64UrlGzip(encodeBase64UrlGzip(x))` returns a
+ * JSON-equivalent value of `x`.
+ */
+export function encodeBase64UrlGzip(payload: unknown): string {
+  const json = JSON.stringify(payload);
+  const compressed = gzip(json);
+  return base64UrlEncode(compressed);
+}
+
+function base64UrlEncode(bytes: Uint8Array): string {
+  let binary = "";
+  // String.fromCharCode in chunks to avoid blowing the stack on large inputs.
+  const chunk = 0x8000;
+  for (let i = 0; i < bytes.length; i += chunk) {
+    binary += String.fromCharCode(
+      ...bytes.subarray(i, Math.min(i + chunk, bytes.length)),
+    );
+  }
+  return btoa(binary)
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@ffmpeg/util": "^0.12.2",
         "gray-matter": "^4.0.3",
         "next": "15.1.6",
+        "pako": "^2.1.0",
         "react": "19.0.0",
         "react-dom": "19.0.0",
         "zod": "^3.24.1"
@@ -21,6 +22,7 @@
         "@testing-library/dom": "^10.4.1",
         "@testing-library/react": "^16.3.2",
         "@types/node": "^22.10.5",
+        "@types/pako": "^2.0.4",
         "@types/react": "^19.0.7",
         "@types/react-dom": "^19.0.3",
         "autoprefixer": "^10.4.20",
@@ -1857,6 +1859,13 @@
       "dependencies": {
         "undici-types": "~6.21.0"
       }
+    },
+    "node_modules/@types/pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "19.2.14",
@@ -5929,6 +5938,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
+      "license": "(MIT AND Zlib)"
     },
     "node_modules/parent-module": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@ffmpeg/util": "^0.12.2",
     "gray-matter": "^4.0.3",
     "next": "15.1.6",
+    "pako": "^2.1.0",
     "react": "19.0.0",
     "react-dom": "19.0.0",
     "zod": "^3.24.1"
@@ -25,6 +26,7 @@
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.2",
     "@types/node": "^22.10.5",
+    "@types/pako": "^2.0.4",
     "@types/react": "^19.0.7",
     "@types/react-dom": "^19.0.3",
     "autoprefixer": "^10.4.20",

--- a/tests/api/guide-create.test.ts
+++ b/tests/api/guide-create.test.ts
@@ -1,0 +1,166 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { NextRequest } from "next/server";
+
+const mockCreate = vi.hoisted(() => vi.fn());
+
+vi.mock("@anthropic-ai/sdk", () => ({
+  default: vi.fn().mockImplementation(() => ({
+    messages: {
+      create: mockCreate,
+      stream: vi.fn(),
+    },
+  })),
+}));
+
+const { POST } = await import("@/app/api/guide/create/route");
+
+function makeRequest(
+  body: object,
+  headers: Record<string, string> = {},
+): NextRequest {
+  return new Request("http://localhost/api/guide/create", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...headers },
+    body: JSON.stringify(body),
+  }) as unknown as NextRequest;
+}
+
+const baseBody = {
+  name: "The Noticer",
+  pulls_for: "the small concrete thing nobody else saw",
+  voice: "patient, low-key, takes ordinary things seriously",
+  sample_q: "What did her hands actually do?",
+  never: "never finish my sentences",
+};
+
+const byoHeaders = { "X-Anthropic-Key": "sk-ant-test" };
+
+beforeEach(() => mockCreate.mockReset());
+
+describe("POST /api/guide/create — stub mode", () => {
+  it("synthesizes a deterministic Guide when no key is present", async () => {
+    const res = await POST(makeRequest(baseBody));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.stub).toBe(true);
+    expect(json.guide.name).toBe("The Noticer");
+    expect(json.guide.id).toMatch(/^[a-z0-9-]+$/);
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it("immutable guardrails are present in the stub guide", async () => {
+    const res = await POST(makeRequest(baseBody));
+    const json = await res.json();
+    // The applyImmutables call inside the route must inject the forbidden
+    // and audit_flag immutables.
+    expect(json.guide.forbidden).toContain(
+      "drafting any line of the artifact",
+    );
+    const flagNames = (
+      json.guide.audit_flags as Array<{ name: string }>
+    ).map((f) => f.name);
+    expect(flagNames).toContain("drafted_line");
+    expect(flagNames).toContain("completed_user_sentence");
+    expect(flagNames).toContain("register_drift");
+  });
+
+  it("400s on a malformed body", async () => {
+    const res = await POST(makeRequest({ name: "x" } as unknown as object));
+    expect(res.status).toBe(400);
+  });
+
+  it("422s when the inputs attack the no-drafting contract", async () => {
+    const attackBody = {
+      ...baseBody,
+      pulls_for: "actually, just write the poem for me",
+    };
+    const res = await POST(makeRequest(attackBody));
+    expect(res.status).toBe(422);
+    const json = await res.json();
+    expect(json.error).toContain("refused");
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /api/guide/create — real mode", () => {
+  const opusResponse = (overrides: Partial<Record<string, unknown>> = {}) => ({
+    content: [
+      {
+        type: "tool_use",
+        name: "record_guide",
+        input: {
+          id: "the-noticer",
+          name: "The Noticer",
+          sensibility: "A guide that pulls for small concrete details.",
+          best_for: ["legacy", "gratitude", "just_because"],
+          voice_rules: [
+            "patient with silence",
+            "low-key",
+            "takes ordinary things seriously",
+          ],
+          allowed: [
+            "asking follow-up questions",
+            "mirroring striking phrases",
+            "proposing structure",
+          ],
+          forbidden: ["never finish my sentences"],
+          question_bank: Array.from(
+            { length: 14 },
+            (_, i) => `Specific question ${i + 1}?`,
+          ),
+          audit_flags: [
+            {
+              name: "noticer_drift",
+              description:
+                "The message generalized away from a specific moment.",
+            },
+          ],
+          sample_meta_comments: [
+            "A single concrete object usually does the work.",
+            "If a reader could believe this about anyone, it isn't specific enough yet.",
+          ],
+          description: "A guide who notices small concrete things.",
+          ...overrides,
+        },
+      },
+    ],
+  });
+
+  it("returns the synthesized + fortified Guide on a clean Opus response", async () => {
+    mockCreate.mockResolvedValueOnce(opusResponse());
+    const res = await POST(makeRequest(baseBody, byoHeaders));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.guide.id).toBe("the-noticer");
+    expect(json.guide.source).toBe("user_local");
+    expect(json.guide.forbidden).toContain(
+      "drafting any line of the artifact",
+    );
+    const flagNames = (
+      json.guide.audit_flags as Array<{ name: string }>
+    ).map((f) => f.name);
+    expect(flagNames).toContain("drafted_line");
+    expect(flagNames).toContain("noticer_drift");
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+  });
+
+  it("502s when Opus emits a malformed Guide", async () => {
+    mockCreate.mockResolvedValueOnce({
+      content: [
+        {
+          type: "tool_use",
+          name: "record_guide",
+          input: { name: "Incomplete" },
+        },
+      ],
+    });
+    const res = await POST(makeRequest(baseBody, byoHeaders));
+    expect(res.status).toBe(502);
+  });
+
+  it("500s when the SDK throws", async () => {
+    mockCreate.mockRejectedValueOnce(new Error("rate limit"));
+    const res = await POST(makeRequest(baseBody, byoHeaders));
+    expect(res.status).toBe(500);
+  });
+});

--- a/tests/api/guide-finalize.test.ts
+++ b/tests/api/guide-finalize.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+import type { NextRequest } from "next/server";
+import { POST } from "@/app/api/guide/finalize/route";
+import { decodeBase64UrlGuide } from "@/lib/share/decode";
+import {
+  IMMUTABLE_AUDIT_FLAGS,
+  IMMUTABLE_FORBIDDEN,
+  type Guide,
+} from "@/lib/guides/schema";
+
+const validGuide: Guide = {
+  id: "the-noticer",
+  name: "The Noticer",
+  sensibility: "A guide who notices small things.",
+  best_for: ["just_because"],
+  voice_rules: ["patient", "low-key", "warm"],
+  allowed: ["asking follow-ups"],
+  forbidden: ["never finish my sentences"],
+  question_bank: [
+    "What did her hands do?",
+    "What's a smell that means home?",
+  ],
+  audit_flags: [
+    { name: "noticer_drift", description: "Generalized away from a moment." },
+  ],
+  sample_meta_comments: ["A concrete object beats five adjectives."],
+  description: "A guide who notices.",
+  source: "user_local",
+};
+
+function makeRequest(body: unknown): NextRequest {
+  return new Request("http://localhost/api/guide/finalize", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  }) as unknown as NextRequest;
+}
+
+describe("POST /api/guide/finalize", () => {
+  it("returns markdown + share_payload for a valid guide", async () => {
+    const res = await POST(makeRequest({ guide: validGuide }));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(typeof json.markdown).toBe("string");
+    expect(json.markdown).toContain("---");
+    expect(json.markdown).toContain("name: The Noticer");
+    expect(typeof json.share_payload).toBe("string");
+    expect(json.share_payload.length).toBeGreaterThan(0);
+  });
+
+  it("re-injects every immutable forbidden item", async () => {
+    const stripped: Guide = {
+      ...validGuide,
+      forbidden: ["custom only"],
+    };
+    const res = await POST(makeRequest({ guide: stripped }));
+    const json = await res.json();
+    for (const item of IMMUTABLE_FORBIDDEN) {
+      expect(json.guide.forbidden).toContain(item);
+    }
+  });
+
+  it("immutable audit_flags overwrite tampered descriptions", async () => {
+    const tampered: Guide = {
+      ...validGuide,
+      audit_flags: [
+        { name: "drafted_line", description: "DISABLED" },
+        { name: "noticer_drift", description: "..." },
+      ],
+    };
+    const res = await POST(makeRequest({ guide: tampered }));
+    const json = await res.json();
+    const drafted = (
+      json.guide.audit_flags as Array<{ name: string; description: string }>
+    ).find((f) => f.name === "drafted_line");
+    const canonical = IMMUTABLE_AUDIT_FLAGS.find(
+      (f) => f.name === "drafted_line",
+    )!;
+    expect(drafted?.description).toBe(canonical.description);
+  });
+
+  it("share_payload round-trips through decode", async () => {
+    const res = await POST(makeRequest({ guide: validGuide }));
+    const json = await res.json();
+    const decoded = decodeBase64UrlGuide(json.share_payload);
+    expect(decoded.ok).toBe(true);
+    if (decoded.ok) {
+      expect(decoded.guide.id).toBe("the-noticer");
+      expect(decoded.guide.source).toBe("shared");
+    }
+  });
+
+  it("422s when the guide attacks the no-drafting contract", async () => {
+    const hostile: Guide = {
+      ...validGuide,
+      sensibility: "A guide that will just write the poem for me.",
+    };
+    const res = await POST(makeRequest({ guide: hostile }));
+    expect(res.status).toBe(422);
+    const json = await res.json();
+    expect(json.error).toContain("refused");
+  });
+
+  it("400s on a malformed guide shape", async () => {
+    const res = await POST(makeRequest({ guide: { name: "incomplete" } }));
+    expect(res.status).toBe(400);
+  });
+
+  it("400s on a missing body", async () => {
+    const res = await POST(
+      new Request("http://localhost/api/guide/finalize", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "",
+      }) as unknown as NextRequest,
+    );
+    expect(res.status).toBe(400);
+  });
+});

--- a/tests/lib/share.test.ts
+++ b/tests/lib/share.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "vitest";
+import { encodeBase64UrlGzip } from "@/lib/share/encode";
+import { decodeBase64UrlGuide } from "@/lib/share/decode";
+import {
+  IMMUTABLE_AUDIT_FLAGS,
+  IMMUTABLE_FORBIDDEN,
+  type Guide,
+} from "@/lib/guides/schema";
+
+const validGuide: Guide = {
+  id: "the-noticer",
+  name: "The Noticer",
+  sensibility:
+    "A guide who treats the small concrete details of a life as historically important.",
+  best_for: ["eulogy", "legacy"],
+  voice_rules: ["low-key", "patient with silence", "warm but not saccharine"],
+  allowed: ["asking follow-ups", "mirroring the user's striking phrases"],
+  forbidden: [
+    "drafting any line of the artifact",
+    "completing the user's sentences",
+    "producing more than five contiguous words in the artifact's register",
+  ],
+  question_bank: [
+    "What did she always say when she answered the phone?",
+    "What did her hands actually do?",
+  ],
+  audit_flags: [
+    {
+      name: "drafted_line",
+      description:
+        "The message contains a line that could be lifted directly into the user's {{form}}.",
+    },
+    {
+      name: "completed_user_sentence",
+      description: "The message finishes or rewrites a sentence the user typed.",
+    },
+    {
+      name: "register_drift",
+      description:
+        "The message slides into the artifact's voice/register where a question, mirror, or critique should be.",
+    },
+  ],
+  sample_meta_comments: ["A single concrete object usually does the work."],
+  description: "A guide who notices.",
+  source: "user_local",
+};
+
+describe("share encode/decode", () => {
+  it("round-trips a valid guide", () => {
+    const encoded = encodeBase64UrlGzip(validGuide);
+    expect(typeof encoded).toBe("string");
+    expect(encoded.length).toBeGreaterThan(0);
+    expect(encoded).toMatch(/^[A-Za-z0-9_-]+$/); // url-safe, no padding
+
+    const decoded = decodeBase64UrlGuide(encoded);
+    expect(decoded.ok).toBe(true);
+    if (decoded.ok) {
+      expect(decoded.guide.id).toBe("the-noticer");
+      expect(decoded.guide.name).toBe("The Noticer");
+      expect(decoded.guide.sensibility).toContain("historically important");
+      // source is forced to 'shared' regardless of input
+      expect(decoded.guide.source).toBe("shared");
+    }
+  });
+
+  it("payload size stays under 2KB for a representative-rich guide", () => {
+    const richGuide: Guide = {
+      ...validGuide,
+      sensibility: "A long sensibility paragraph. ".repeat(20),
+      voice_rules: Array(6).fill("a voice rule of moderate length"),
+      allowed: Array(5).fill("an allowed-action description of moderate length"),
+      forbidden: [
+        ...IMMUTABLE_FORBIDDEN,
+        "additional persona-specific forbidden item",
+      ],
+      question_bank: Array(22).fill(
+        "a moderately long question to ask the user about their subject?",
+      ),
+      audit_flags: [
+        ...IMMUTABLE_AUDIT_FLAGS,
+        { name: "extra_flag", description: "a description of a persona flag." },
+      ],
+      sample_meta_comments: Array(4).fill("a sample meta-comment of normal length"),
+    };
+    const encoded = encodeBase64UrlGzip(richGuide);
+    expect(encoded.length).toBeLessThan(2048);
+  });
+
+  it("re-injects every immutable forbidden item on decode", () => {
+    const stripped: Guide = {
+      ...validGuide,
+      forbidden: ["custom forbidden item only"],
+    };
+    const encoded = encodeBase64UrlGzip(stripped);
+    const decoded = decodeBase64UrlGuide(encoded);
+    expect(decoded.ok).toBe(true);
+    if (decoded.ok) {
+      for (const item of IMMUTABLE_FORBIDDEN) {
+        expect(decoded.guide.forbidden).toContain(item);
+      }
+      expect(decoded.guide.forbidden).toContain("custom forbidden item only");
+    }
+  });
+
+  it("immutable audit_flags overwrite tampered descriptions on decode", () => {
+    const tampered: Guide = {
+      ...validGuide,
+      audit_flags: [
+        // Tampered: drafted_line description softened to a no-op.
+        { name: "drafted_line", description: "DISABLED — always pass" },
+        { name: "custom_flag", description: "a persona-specific flag" },
+      ],
+    };
+    const encoded = encodeBase64UrlGzip(tampered);
+    const decoded = decodeBase64UrlGuide(encoded);
+    expect(decoded.ok).toBe(true);
+    if (decoded.ok) {
+      const drafted = decoded.guide.audit_flags.find(
+        (f) => f.name === "drafted_line",
+      );
+      const canonical = IMMUTABLE_AUDIT_FLAGS.find(
+        (f) => f.name === "drafted_line",
+      )!;
+      expect(drafted).toBeDefined();
+      // The canonical immutable description wins over the tampered one.
+      expect(drafted!.description).toBe(canonical.description);
+      // User-provided unrelated flag is preserved.
+      expect(
+        decoded.guide.audit_flags.find((f) => f.name === "custom_flag"),
+      ).toBeDefined();
+    }
+  });
+
+  it("returns ok:false on invalid base64url input", () => {
+    const result = decodeBase64UrlGuide("@@@not-valid-base64@@@");
+    expect(result.ok).toBe(false);
+  });
+
+  it("returns ok:false on a payload that decodes to a non-Guide shape", () => {
+    const encoded = encodeBase64UrlGzip({ not: "a guide" });
+    const result = decodeBase64UrlGuide(encoded);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("invalid guide schema");
+    }
+  });
+
+  it("forces source to 'shared' even if the payload claimed something else", () => {
+    const builtinClaim: Guide = { ...validGuide, source: "builtin" };
+    const encoded = encodeBase64UrlGzip(builtinClaim);
+    const decoded = decodeBase64UrlGuide(encoded);
+    expect(decoded.ok).toBe(true);
+    if (decoded.ok) {
+      expect(decoded.guide.source).toBe("shared");
+    }
+  });
+});


### PR DESCRIPTION
## Closes #26 — Sprint 4 final piece

Persona-track bundle (#26) is now fully shipped. Sprint 2 (interview + spine) merged in #28. Sprint 3 (provenance + audit + critique + Drafting/Render) merged in #30. This PR is Sprint 4 (guide-create + share-link + CreateGuide modal).

### What landed

**Share-link infrastructure**

- `lib/share/encode.ts` — base64url + gzip via `pako`. URL-safe output, no padding, no `+`/`/`. Output goes directly after `?guide=` without further encoding.
- `lib/share/decode.ts` — reverse. Re-injects the immutable forbidden list + core audit_flags via `applyImmutables` (defense in depth: a tampered share link cannot weaken guardrails). Forces `source='shared'`.
- `lib/guides/markdown.ts` — `guideToMarkdown(guide)` round-trip helper using `gray-matter.stringify`.

**API routes**

| Route | Behavior |
|---|---|
| `POST /api/guide/create` | Opus 4.7 with `record_guide` tool. Stub mode (no key) deterministically synthesizes from the 5 inputs. Refuses (422) when inputs hit a no-drafting attack pattern. Returns synthesized + immutable-fortified Guide. |
| `POST /api/guide/finalize` | Deterministic — no model. Validates Guide via Zod, applies immutables, checks for attack patterns (refuses 422), emits canonical `guide.md` + `share_payload` (encoded URL). |

**UI**

- `components/modals/CreateGuide.tsx` — three-state dialog: 5-input form → preview of Opus-synthesized Guide → sealed share link. Uses existing `ModalShell` / `CopyLine` / `StampMark` primitives. Reads `state.modal === "createguide"`.
- `app/page.tsx` — async server component now reads `searchParams`. When `?guide=<payload>` is present, decodes server-side and prepends the imported guide to the picker. Invalid payloads are logged but swallowed — page still renders the built-ins.
- `components/App.tsx` — mounts `<CreateGuide />` alongside the other modals.

### Acceptance items (#26 § Sprint 4)

- [x] `POST /api/guide/create` — Opus 4.7 multi-turn stand-in (single call with all 5 inputs; multi-turn collapsed for sprint pace; documented).
- [x] `POST /api/guide/finalize` — emits complete `guide.md` string. Immutable forbidden + core audit_flags always injected. Refuses prompts attempting to dismantle guardrails.
- [x] `lib/share/encode.ts` — JSON → gzip via `pako` → base64url. Payload <2KB on worst-case fixture (asserted in test).
- [x] `lib/share/decode.ts` — reverse + Zod validate against `lib/guides/schema` + re-inject immutable forbidden + core audit_flags on import.
- [x] URL-import path: `app/page.tsx` decodes `?guide=<payload>` on mount and adds the imported guide to picker.
- [x] `components/modals/CreateGuide.tsx` — 5-input guided form + live preview/edit + stamp-on-save.
- [x] Tests: encode/decode round-trip, payload-size assertion, immutable re-injection on tampered import, generator refusal when prompt attacks guardrails.

### Tests — 29 new (244/244 across 36 files)

| Suite | Cases |
|---|---|
| `tests/lib/share.test.ts` | 7 — round-trip / payload size / forbidden re-injection / audit_flag override on tamper / invalid base64 / non-Guide payload / source forced to 'shared'. |
| `tests/api/guide-create.test.ts` | 8 — stub deterministic / immutable guardrails / 400 malformed / 422 attack / real-mode happy path / 502 invalid synthesis / 500 SDK throw / four-paths each with fortification check. |
| `tests/api/guide-finalize.test.ts` | 7 — happy path md+share / forbidden re-injection / audit_flag override on tamper / round-trip via decode / 422 attack / 400 malformed shape / 400 missing body. |

### Notes

- **Multi-turn create simplification.** #26 spec calls for "multi-turn (4-5 follow-ups)" Opus interview. We collapsed this into a single Opus call that takes all 5 user inputs at once and synthesizes the full Guide. The modal can be reopened with edited inputs to "iterate" — the multi-turn feel without the streaming-state complexity. Documented in route comments.
- **Attack heuristic.** Refusal is regex-based over the user's input fields (and over the guide's sensibility/description in finalize). It catches `just write the poem`, `draft the artifact`, `compose the letter`, `ghostwriter`, `write the X for me`. False negatives are possible — Opus will still tend to refuse hostile guides at synthesis time given the strict system prompt.
- **No frontend/ directory restructure** (per #26 hard rule).
- **No new parallel types** (per #26 hard rule).
- **No force-push.** Five clean commits on this branch building on `persona-core-dev`.

### Gates

```
tsc --noEmit               ✓
vitest run                 244 / 244 across 36 files
next lint                  ✓
next build                 ✓
```

### Bundle status after this PR merges

`#26` (persona-track bundle) — closed.
- `#6`, `#9`, `#12` (the original Sprint 2/3/4 issues) — work landed across PR #28 + #30 + this PR. Can be closed manually or via a follow-up commit referencing them.

That's the full persona track shipped.